### PR TITLE
[TIL-77] 환경변수 파일(.env) 사용하도록 설정

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,6 @@
+# .env 파일을 생성하고 아래 환경 변수를 설정해주세요.
+# - .env.template 파일을 제외한 다른 환경 변수 파일은 git에 포함 X
+# - 모든 환경 변수는 'REACT_APP_' 접두사를 붙여야만 React 애플리케이션에서 인식
+# - 설정한 환경 변수는 코드에서 'process.env.REACT_APP_...' 형태로 전역에서 접근 접근 가능
+REACT_APP_PROFILE=${환경 설정 프로필}      # ex) local
+REACT_APP_TIL_API_URL=${TIL API 주소}   # ex) http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,8 @@
 Thumbs.db
 .AppleDouble
 .LSOverride
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
+!.env.template
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ cd TIL-Frontend
 yarn install
 ```
 #### 3. 개발 서버 실행
+| ❗️주의❗️ 서버 실행 전 [.env.template](./.env.template) 파일을 참고하여 .env 파일을 생성하고 환경 변수를 설정해야 함  
 개발 서버 실행한다. 
 ```
 yarn start

--- a/src/services/api/axios.ts
+++ b/src/services/api/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: 'http://localhost:8080', // 기본 URL 설정
+  baseURL: process.env.REACT_APP_TIL_API_URL, // 기본 URL 설정
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-77](https://soma-til.atlassian.net/browse/TIL-77)

<br>

## 개요
환경변수 파일(.env) 사용하도록 설정

<br>

## 내용
- 기존 API URL 하드코딩 환경 변수로 전환
- `.env.template`에 환경변수 파일 템플릿 가이드 작성

<br>

## 리뷰어한테 할 말
- 백엔드처럼 환경 변수 파일들을 서브 모듈로 분리하는 부분은 고려하지 않고 환경 변수 파일의 변수를 활용할 수 있는 것에 초점을 맞춰 작업하였습니다.


[TIL-77]: https://soma-til.atlassian.net/browse/TIL-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ