### PR TITLE
[TIL-74] 회원 가입 실패시 에러 응답 메시지 가시화

### DIFF
--- a/src/components/pages/JoinPage/JoinPage.tsx
+++ b/src/components/pages/JoinPage/JoinPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { JoinData, join } from '@services/api/userService';
 import { alertError } from '@utils/errorHandler';
+import { showAlertPopup } from '@utils/showPopup';
 import './JoinPage.css';
 
 const JoinPage: React.FC = () => {
@@ -17,8 +18,7 @@ const JoinPage: React.FC = () => {
 
     try {
       await join(joinData);
-      // eslint-disable-next-line no-alert
-      alert('회원가입 성공');
+      showAlertPopup('회원가입 성공');
       navigate('/');
     } catch (err) {
       alertError(err);

--- a/src/components/pages/JoinPage/JoinPage.tsx
+++ b/src/components/pages/JoinPage/JoinPage.tsx
@@ -1,26 +1,27 @@
 import React, { useState, FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { JoinData, join } from '@services/api/userService';
+import { alertError } from '@utils/errorHandler';
 import './JoinPage.css';
 
 const JoinPage: React.FC = () => {
+  const navigate = useNavigate();
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [nickname, setNickname] = useState<string>('');
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<boolean>(false);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setError(null);
-
     const joinData: JoinData = { email, password, nickname };
 
     try {
       await join(joinData);
-      setSuccess(true);
+      // eslint-disable-next-line no-alert
+      alert('회원가입 성공');
+      navigate('/');
     } catch (err) {
-      setError('Join failed. Please try again.');
+      alertError(err);
     }
   };
 
@@ -60,8 +61,6 @@ const JoinPage: React.FC = () => {
         </div>
         <button type="submit">Signup</button>
       </form>
-      {error && <p className="error">{error}</p>}
-      {success && <p className="success">Signup successful!</p>}
     </div>
   );
 };

--- a/src/components/pages/LoginPage/LoginPage.tsx
+++ b/src/components/pages/LoginPage/LoginPage.tsx
@@ -5,6 +5,7 @@ import { LoginData, login } from '@services/api/userService';
 import { setCookie } from '@services/cookie';
 import useAuthStore from '@store/useAuthStore';
 import { alertError } from '@utils/errorHandler';
+import { showAlertPopup } from '@utils/showPopup';
 import { Token } from '@type/auth';
 
 const LoginPage: React.FC = () => {
@@ -21,8 +22,7 @@ const LoginPage: React.FC = () => {
       const { accessToken, refreshToken } = response.result as Token;
       useAuthStore.getState().setAccessToken(accessToken);
       setCookie('refreshToken', refreshToken);
-      // eslint-disable-next-line no-alert
-      alert('로그인 성공');
+      showAlertPopup('로그인 성공');
       navigate('/');
     } catch (err: unknown) {
       alertError(err);

--- a/src/services/api/userService.ts
+++ b/src/services/api/userService.ts
@@ -7,7 +7,7 @@ export interface JoinData {
   nickname: string;
 }
 
-export const join = async (data: JoinData) => {
+export const join = async (data: JoinData): Promise<ApiResponse> => {
   const response = await apiClient.post('/user/join', data);
   return response.data;
 };

--- a/src/utils/showPopup.ts
+++ b/src/utils/showPopup.ts
@@ -1,0 +1,8 @@
+/* eslint-disable */
+export const showAlertPopup = (message: string): void => {
+  window.alert(message);
+};
+
+export const showConfirmPopup = (): void => {
+  // TODO: Implement this function
+};


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-74](https://soma-til.atlassian.net/browse/TIL-74)

<br>

## 개요
회원 가입 실패시 에러 응답 메시지 가시화

<br>

## 내용
- 회원 가입 실패시 에러 응답 메시지 가시화
- 팝업 관련 이벤트 util 함수로 분리
<img src="https://github.com/user-attachments/assets/6d65c70f-8ff3-46a5-9b8a-72025b9de139" width=500 />

<br>

## 리뷰어한테 할 말
😀

[TIL-74]: https://soma-til.atlassian.net/browse/TIL-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ