### PR TITLE
[TIL-82] CD worlflow error 해결

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -23,16 +23,13 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.dev -t ${{ secrets.DOCKER_USERNAME }}/til-front:latest --push .
+          docker buildx build --platform linux/amd64 -f Dockerfile.dev -t ${{ secrets.DOCKER_USERNAME }}/til-front:latest --push .
 
   deploy:
     runs-on: ubuntu-latest
     needs: build_and_push
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v0.1.5
         with:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t ${{ secrets.DOCKER_USERNAME }}/til-front:latest --push .
+          docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.dev -t ${{ secrets.DOCKER_USERNAME }}/til-front:latest --push .
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-82](https://soma-til.atlassian.net/browse/TIL-82)

<br>

## 개요

- CD workflow error 해결

<br>

## 내용

- 문제: buildx 빌드 시, 다음과 같은 에러 발생
   "ERROR: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory"
- 원인: Dockerfile.dev 파일을 찾지 못함. 
- 해결: 명령어에 -f Dockerfile.dev 추가 

- 추가 변경 사항
   - buildx 서버 아키텍처인 linux/amd64을 위한 플랫폼으로만 빌드 -> 빌드 시간 단축됨. 
   - deploy 단계에서 check 삭제
   
<br>

## 리뷰어한테 할 말

- 너무 기본적인 부분인데,,다른 곳에서 테스트하다 놓쳤네요🥲


[TIL-82]: https://soma-til.atlassian.net/browse/TIL-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ