### PR TITLE
[TIL-93] API 요청시 JWT 토큰을 자동으로 포함시켜 요청

### DIFF
--- a/src/services/api/axios.ts
+++ b/src/services/api/axios.ts
@@ -1,10 +1,113 @@
-import axios from 'axios';
+/* eslint-disable */
+import { getCookie, removeCookie, setCookie } from '@services/cookie';
+import useAuthStore from '@store/useAuthStore';
+import { ApiResponse } from '@type/api';
+import { Token } from '@type/auth';
+import axios, { AxiosResponse } from 'axios';
 
+// axios 인스턴스 생성
 const apiClient = axios.create({
   baseURL: process.env.REACT_APP_TIL_API_URL, // 기본 URL 설정
   headers: {
     'Content-Type': 'application/json',
   },
 });
+
+// 요청 인터셉터 : 요청을 보내기 전에 토큰을 헤더에 추가
+apiClient.interceptors.request.use(
+  (config) => {
+    const newConfig = { ...config };
+    const accessToken = useAuthStore.getState().getAccessToken();
+    newConfig.headers.Authorization = accessToken ? `Bearer ${accessToken}` : ''; // 헤더에 토큰 추가
+
+    return newConfig;
+  },
+  (error) => Promise.reject(error), // 요청 중 에러가 발생하면 거부
+);
+
+let isRefreshing = false; // 토큰 갱신 중인지 여부를 나타내는 플래그
+let failedQueue: any[] = []; // 요청이 실패한 후 대기 중인 요청들을 저장하는 큐
+
+// 실패한 요청들을 처리하는 함수
+const processQueue = (error: Error | unknown, accessToken: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error); // 에러 발생 시, 대기 중인 요청을 모두 거부
+    } else {
+      prom.resolve(accessToken); // 성공 시, 대기 중인 요청에 새로운 토큰으로 재시도
+    }
+  });
+  failedQueue = [];
+};
+
+// 응답 인터셉터 : 응답이 돌아오면 처리
+apiClient.interceptors.response.use(
+  (response: AxiosResponse) => response, // 응답이 성공적이면 그대로 반환
+  async (error) => {
+    const originalRequest = error.config; // 실패한 요청 정보를 가져옴
+
+    // 401 Unauthorized 에러가 발생하고, 아직 재시도를 하지 않은 경우
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true; // 재시도 플래그 설정
+
+      if (isRefreshing) {
+        // 이미 토큰 갱신 중인 경우
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject }); // 대기 중인 요청에 추가
+        })
+          .then((token) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`; // 새로운 토큰으로 헤더 업데이트
+            return apiClient(originalRequest); // 요청을 다시 시도
+          })
+          .catch((err) => Promise.reject(err)); // 에러 발생 시 거부
+      }
+
+      isRefreshing = true; // 토큰 갱신 시작
+
+      // 토큰 갱신 시도
+      return new Promise((resolve, reject) => {
+        refreshToken()
+          .then((response) => {
+            const { token } = response.result as { token: Token };
+
+            useAuthStore.getState().setAccessToken(token.accessToken);
+            setCookie('refreshToken', token.refreshToken);
+
+            apiClient.defaults.headers.common.Authorization = `Bearer ${token.accessToken}`; // 기본 헤더 업데이트
+            originalRequest.headers.Authorization = `Bearer ${token.accessToken}`; // 요청 헤더 업데이트
+            processQueue(null, token.accessToken); // 대기 중인 요청 처리
+            resolve(apiClient(originalRequest)); // 원래 요청 재시도
+          })
+          .catch((err) => {
+            removeCookie('refreshToken');
+            processQueue(err, null); // 에러 발생 시 대기 중인 요청 모두 거부
+            reject(err); // 에러 반환
+          })
+          .finally(() => {
+            isRefreshing = false; // 토큰 갱신 종료
+          });
+      });
+    }
+
+    return Promise.reject(error); // 401 이외의 에러는 그대로 거부
+  },
+);
+
+// 리프레시 토큰을 사용해 새로운 액세스 토큰을 요청하는 함수
+const refreshToken = async (): Promise<ApiResponse> => {
+  try {
+    const refreshToken = getCookie('refreshToken');
+    const response = await axios.get(`${process.env.REACT_APP_TIL_API_URL}/auth/reissue`, {
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error refreshing token:', error);
+    throw error; // 에러 발생 시 예외를 던짐
+  }
+};
 
 export default apiClient;

--- a/src/services/cookie.ts
+++ b/src/services/cookie.ts
@@ -4,8 +4,7 @@ import { CookieSetOptions } from 'universal-cookie';
 const cookies = new Cookies();
 
 const defaultOptions: CookieSetOptions = {
-  httpOnly: true, // 클라이언트 측 자바스크립트에서 접근 불가
-  secure: true, // HTTPS 프로토콜에서만 전송
+  secure: process.env.REACT_APP_PROFILE !== 'local', // HTTPS 프로토콜에서만 전송
 };
 
 export const setCookie = (name: string, value: string, options?: CookieSetOptions) => {
@@ -13,3 +12,5 @@ export const setCookie = (name: string, value: string, options?: CookieSetOption
 };
 
 export const getCookie = (name: string) => cookies.get(name);
+
+export const removeCookie = (name: string) => cookies.remove(name);


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-93](https://soma-til.atlassian.net/browse/TIL-93)

<br>

## 개요
API 요청시 JWT 토큰을 자동으로 포함시켜 요청

<br>

## 내용
- axios interceptor를 활용하여 API 요청시 access 토큰을 자동으로 포함시켜 요청
- access 토큰 만료시 refresh 토큰을 사용해 토큰 재발급 후 다시 이전에 실패했던 요청들 재전송

<br>

## 리뷰어한테 할 말
- 이해를 위해 평소보다 주석을 많이 작성했습니다.



[TIL-93]: https://soma-til.atlassian.net/browse/TIL-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ