### PR TITLE
[TIL-98] 권한별(사용자의 로그인 상태) 페이지 접근 세팅

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     'no-param-reassign': ['error', { props: true, ignorePropertyModificationsFor: ['state'] }],
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either', depth: 3 }],
     'import/no-extraneous-dependencies': 'off',
+    'react/require-default-props': 'off',
     'react/function-component-definition': [
       'error',
       { namedComponents: 'arrow-function', unnamedComponents: 'arrow-function' },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,14 +5,26 @@ import PageLayout from '@components/layout/PageLayout';
 
 import JoinPage from '@components/pages/JoinPage/JoinPage';
 import LoginPage from '@components/pages/LoginPage/LoginPage';
+import PrivateRoute from './route';
 import './App.css';
 
 const App: React.FC = () => (
   <PageLayout>
     <Routes>
+      {/* 인증 여부 상관 없이 접속 가능한 페이지 정의 */}
       <Route path="/" element={<div>메인페이지</div>} />
-      <Route path="/join" element={<JoinPage />} />
-      <Route path="/login" element={<LoginPage />} />
+      <Route path="/problem" element={<div>기술학습</div>} />
+
+      {/* 인증이 필요한 페이지 정의 */}
+      <Route element={<PrivateRoute />}>
+        <Route path="/mypage" element={<div>마이페이지</div>} />
+        <Route path="/interview" element={<div>기술면접</div>} />
+      </Route>
+      {/* 인증을 하지 않아야만 접속 가능한 페이지 정의 */}
+      <Route element={<PrivateRoute authentication={false} />}>
+        <Route path="/join" element={<JoinPage />} />
+        <Route path="/login" element={<LoginPage />} />
+      </Route>
     </Routes>
   </PageLayout>
 );

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -1,0 +1,18 @@
+import { getCookie } from '@services/cookie';
+import { Navigate, Outlet } from 'react-router-dom';
+
+interface PrivateRouteProps {
+  authentication?: boolean;
+}
+
+const PrivateRoute = ({ authentication = true }: PrivateRouteProps): React.ReactElement | null => {
+  const isAuthenticated = Boolean(getCookie('refreshToken'));
+
+  if (authentication) {
+    return isAuthenticated ? <Outlet /> : <Navigate to="/login" />;
+  }
+
+  return isAuthenticated ? <Navigate to="/" /> : <Outlet />;
+};
+
+export default PrivateRoute;


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-98](https://soma-til.atlassian.net/browse/TIL-98)

<br>

## 개요
권한별(사용자의 로그인 상태) 페이지 접근 세팅

<br>

## 내용
- 권한(사용자의 로그인 상태)에 따라 페이지 접근 route를 세팅


<br>

## 리뷰어한테 할 말
- 현재 관리자 페이지 구현을 미뤄둔 상태이기 때문에  
   사용자 정보 중 ROLE의 권한(일반 사용자, 관리자)에 따라 route 되는 부분은 진행하지 않았습니다!
- 헤더 부분 권한별 보이는 메뉴 다르게 구성되도록 설정하는 부분은 별도 task 로 작업할 예정입니다!

[TIL-98]: https://soma-til.atlassian.net/browse/TIL-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ