### PR TITLE
[TIL-97] constant 분리

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -6,6 +6,7 @@ module.exports = {
   webpack: {
     alias: {
       '@components': path.resolve(__dirname, 'src/components/'),
+      '@constants': path.resolve(__dirname, 'src/constants/'),
       '@services': path.resolve(__dirname, 'src/services/'),
       '@store': path.resolve(__dirname, 'src/store/'),
       '@type': path.resolve(__dirname, 'src/type/'),

--- a/src/components/pages/LoginPage/LoginPage.tsx
+++ b/src/components/pages/LoginPage/LoginPage.tsx
@@ -1,14 +1,15 @@
 import React, { useState, FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { REFRESH_TOKEN } from '@constants/auth';
 import { LoginData, login } from '@services/api/userService';
 import { setCookie } from '@services/cookie';
 import useAuthStore from '@store/useAuthStore';
+import useUserInfoStore from '@store/useUserInfoStore';
 import { alertError } from '@utils/errorHandler';
 import { showAlertPopup } from '@utils/showPopup';
 import { Token } from '@type/auth';
 import { UserInfo } from '@type/user';
-import useUserInfoStore from '@store/useUserInfoStore';
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
@@ -25,7 +26,7 @@ const LoginPage: React.FC = () => {
 
       useAuthStore.getState().setAccessToken(token.accessToken);
       useUserInfoStore.getState().setNickname(user.nickname);
-      setCookie('refreshToken', token.refreshToken);
+      setCookie(REFRESH_TOKEN, token.refreshToken);
 
       showAlertPopup('로그인 성공');
       navigate('/');

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,0 +1,4 @@
+export const REFRESH_TOKEN = 'token';
+export const BEARER = 'Bearer';
+
+export const formatBearerToken = (token: string): string => `${BEARER} ${token}`;

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,0 +1,4 @@
+export const LOCAL_PROFILE = 'local';
+export const DEV_PROFILE = 'dev';
+export const PROD_PROFILE = 'prod';
+export const TEST_PROFILE = 'test';

--- a/src/services/cookie.ts
+++ b/src/services/cookie.ts
@@ -1,10 +1,12 @@
 import { Cookies } from 'react-cookie';
 import { CookieSetOptions } from 'universal-cookie';
 
+import { LOCAL_PROFILE } from '@constants/env';
+
 const cookies = new Cookies();
 
 const defaultOptions: CookieSetOptions = {
-  secure: process.env.REACT_APP_PROFILE !== 'local', // HTTPS 프로토콜에서만 전송
+  secure: process.env.REACT_APP_PROFILE !== LOCAL_PROFILE, // HTTPS 프로토콜에서만 전송
 };
 
 export const setCookie = (name: string, value: string, options?: CookieSetOptions) => {

--- a/src/store/support.ts
+++ b/src/store/support.ts
@@ -1,8 +1,10 @@
 import { create, StateCreator } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
+import { PROD_PROFILE } from '@constants/env';
+
 const storeSupport = <T>(initializer: StateCreator<T>, storeName: string) =>
-  process.env.REACT_APP_PROFILE === 'prod'
+  process.env.REACT_APP_PROFILE === PROD_PROFILE
     ? create<T>()(initializer)
     : create<T>()(devtools(initializer, { name: storeName }));
 

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,8 +1,12 @@
+// 절대경로 설정을 위한 tsconfig.paths.json 파일
+// tsconfig.json 파일에 extends로 추가하여 사용
+// craco.config.js 파일에도 설정 추가 필요
 {
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
       "@components/*": ["src/components/*"],
+      "@constants/*": ["src/constants/*"],
       "@services/*": ["src/services/*"],
       "@store/*": ["src/store/*"],
       "@type/*": ["src/type/*"],


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-97](https://soma-til.atlassian.net/browse/TIL-97)

<br>

## 개요
constant 분리
- 목적 : 코드 가독성 향상 및 유지보수를 위함
- constant 분리 적용 대상 : API 관련 반복되는 부분, env 프로필
<br>

## 내용
- constants 디렉토리 절대경로 추가
- API 세팅시 auth 관련 부분 constant 분리
- env 프로필 constant 분리

<br>

## 리뷰어한테 할 말
😀


[TIL-97]: https://soma-til.atlassian.net/browse/TIL-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ