### PR TITLE
[TIL-102] Header 권한별로 다르게 보이도록 구성

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,15 +1,27 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import HeaderMenuButton from '@components/layout/HeaderMenuButton/HeaderMenuButton';
-
+import useAuthStore from '@store/useAuthStore';
 import './Header.css';
 
 const Header: React.FC = () => {
   const navigate = useNavigate();
+  const { isAuthenticated, logout, checkAuthentication } = useAuthStore();
+
+  useEffect(() => {
+    checkAuthentication();
+  }, [checkAuthentication]);
 
   const handleHomeButton = () => {
     navigate('/');
   };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
   return (
     <header className="Header">
       <button type="button" className="LogoButton" onClick={handleHomeButton}>
@@ -17,8 +29,19 @@ const Header: React.FC = () => {
       </button>
       <HeaderMenuButton title="기술 학습" path="/problem" />
       <HeaderMenuButton title="기술 면접" path="/interview" />
-      <HeaderMenuButton title="로그인" path="/login" />
-      <HeaderMenuButton title="회원가입" path="/join" />
+
+      {!isAuthenticated && (
+        <>
+          <HeaderMenuButton title="로그인" path="/login" />
+          <HeaderMenuButton title="회원가입" path="/join" />
+        </>
+      )}
+      {isAuthenticated && (
+        <>
+          <HeaderMenuButton title="마이페이지" path="/mypage" />
+          <HeaderMenuButton title="로그아웃" path="/logout" onClick={handleLogout} />
+        </>
+      )}
     </header>
   );
 };

--- a/src/components/layout/HeaderMenuButton/HeaderMenuButton.tsx
+++ b/src/components/layout/HeaderMenuButton/HeaderMenuButton.tsx
@@ -5,13 +5,17 @@ import './HeaderMenuButton.css';
 interface HeaderMenuButtonProps {
   title: string;
   path: string;
+  onClick?: () => void;
 }
 
-const HeaderMenuButton: React.FC<HeaderMenuButtonProps> = ({ title, path }) => {
+const HeaderMenuButton: React.FC<HeaderMenuButtonProps> = ({ title, path, onClick }) => {
   const navigate = useNavigate();
 
   const handleHeaderMenuButton = () => {
-    navigate(path);
+    if (onClick) {
+      return onClick();
+    }
+    return navigate(path);
   };
 
   return (

--- a/src/components/pages/LoginPage/LoginPage.tsx
+++ b/src/components/pages/LoginPage/LoginPage.tsx
@@ -1,9 +1,7 @@
 import React, { useState, FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { REFRESH_TOKEN } from '@constants/auth';
 import { LoginData, login } from '@services/api/userService';
-import { setCookie } from '@services/cookie';
 import useAuthStore from '@store/useAuthStore';
 import useUserInfoStore from '@store/useUserInfoStore';
 import { alertError } from '@utils/errorHandler';
@@ -24,9 +22,8 @@ const LoginPage: React.FC = () => {
       const response = await login(loginData);
       const { token, user } = response.result as { token: Token; user: UserInfo };
 
-      useAuthStore.getState().setAccessToken(token.accessToken);
+      useAuthStore.getState().login(token);
       useUserInfoStore.getState().setNickname(user.nickname);
-      setCookie(REFRESH_TOKEN, token.refreshToken);
 
       showAlertPopup('로그인 성공');
       navigate('/');

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -1,13 +1,12 @@
-import { getCookie } from '@services/cookie';
 import { Navigate, Outlet } from 'react-router-dom';
+import useAuthStore from '@store/useAuthStore';
 
 interface PrivateRouteProps {
   authentication?: boolean;
 }
 
 const PrivateRoute = ({ authentication = true }: PrivateRouteProps): React.ReactElement | null => {
-  const isAuthenticated = Boolean(getCookie('refreshToken'));
-
+  const { isAuthenticated } = useAuthStore();
   if (authentication) {
     return isAuthenticated ? <Outlet /> : <Navigate to="/login" />;
   }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,10 +1,17 @@
+import { REFRESH_TOKEN } from '@constants/auth';
+import { getCookie, removeCookie, setCookie } from '@services/cookie';
 import storeSupport from '@store/support';
+import { Token } from '@type/auth';
 
 interface AccessTokenInfo {
+  isAuthenticated: boolean;
+  checkAuthentication: () => void;
   accessToken: string;
   setAccessToken: (accessToken: string) => void;
   getAccessToken: () => string;
-  deleteTokens: () => void;
+  deleteAccessToken: () => void;
+  login: (token: Token) => void;
+  logout: () => void;
 }
 
 const useAuthStore = storeSupport<AccessTokenInfo>(
@@ -12,7 +19,21 @@ const useAuthStore = storeSupport<AccessTokenInfo>(
     accessToken: '',
     setAccessToken: (accessToken) => set({ accessToken }),
     getAccessToken: () => get().accessToken,
-    deleteTokens: () => set({ accessToken: '' }),
+    deleteAccessToken: () => set({ accessToken: '' }),
+    isAuthenticated: Boolean(getCookie(REFRESH_TOKEN)),
+    checkAuthentication: () => {
+      set({ isAuthenticated: Boolean(getCookie(REFRESH_TOKEN)) });
+    },
+    login: (token) => {
+      setCookie(REFRESH_TOKEN, token.refreshToken);
+      get().setAccessToken(token.accessToken);
+      set({ isAuthenticated: true });
+    },
+    logout: () => {
+      removeCookie(REFRESH_TOKEN);
+      get().deleteAccessToken();
+      set({ isAuthenticated: false });
+    },
   }),
   'AUTH_STORE',
 );


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-102](https://soma-til.atlassian.net/browse/TIL-102)

<br>

## 개요
권한별로 보이는 메뉴가 다르게 구성될 수 있도록 설정

<br>

## 내용
- Header 권한별로 다르게 보이도록 구성
  - 로그인한 사용자 : 기술학습, 기술면접, 마이페이지
  - 로그인하지 않은 사용자 : 기술학습, 기술면접, 로그인, 회원가입
- useAuthStore에 로그인, 로그아웃시 정보 처리 로직 분리

https://github.com/user-attachments/assets/ffa47ac3-bad9-426c-ad55-8527e1cc3ae6





<br>

## 리뷰어한테 할 말
😀


[TIL-102]: https://soma-til.atlassian.net/browse/TIL-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ