### PR TITLE
[TIL-105] 모의 면접 구성 화면 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import PageLayout from '@components/layout/PageLayout';
 
 import JoinPage from '@components/pages/JoinPage/JoinPage';
 import LoginPage from '@components/pages/LoginPage/LoginPage';
+import InterviewIntroPage from '@components/pages/InterviewIntroPage/InterviewIntroPage';
 import PrivateRoute from './route';
 import './App.css';
 
@@ -15,10 +16,12 @@ const App: React.FC = () => (
       <Route path="/" element={<div>메인페이지</div>} />
       <Route path="/problem" element={<div>기술학습</div>} />
 
+      {/* 인증 여부 상관 없이 접속 가능한 페이지: 개발 단계동안만 임시로 올려두는 페이지 */}
+      <Route path="/interview" element={<InterviewIntroPage />} />
+
       {/* 인증이 필요한 페이지 정의 */}
       <Route element={<PrivateRoute />}>
         <Route path="/mypage" element={<div>마이페이지</div>} />
-        <Route path="/interview" element={<div>기술면접</div>} />
       </Route>
       {/* 인증을 하지 않아야만 접속 가능한 페이지 정의 */}
       <Route element={<PrivateRoute authentication={false} />}>

--- a/src/components/layout/SelectBox/SelectBox.tsx
+++ b/src/components/layout/SelectBox/SelectBox.tsx
@@ -1,0 +1,21 @@
+interface OptionInterface {
+  value: string;
+  name: string;
+}
+interface SelectBoxProps {
+  optionList: OptionInterface[];
+  value: string;
+  onChange: React.ChangeEventHandler;
+}
+
+const SelectBox: React.FC<SelectBoxProps> = ({ optionList, value, onChange }) => (
+  <select onChange={onChange} value={value}>
+    {optionList.map((option) => (
+      <option value={option.value} key={option.value}>
+        {option.name}
+      </option>
+    ))}
+  </select>
+);
+
+export default SelectBox;

--- a/src/components/layout/TabButton/TabButton.css
+++ b/src/components/layout/TabButton/TabButton.css
@@ -1,0 +1,20 @@
+.TabButton {
+  color: black;
+  background-color: rgb(226, 226, 226);
+  border-radius: 10px 10px 0px 0px;
+}
+
+.selected {
+  background-color: rgb(200, 200, 200);
+}
+
+.TabButton:hover {
+  color: blue;
+  background-color: rgb(226, 226, 226);
+}
+
+.selected:hover {
+  color: black;
+  background-color: rgb(200, 200, 200);
+  cursor: default;
+}

--- a/src/components/layout/TabButton/TabButton.tsx
+++ b/src/components/layout/TabButton/TabButton.tsx
@@ -1,0 +1,21 @@
+import './TabButton.css';
+
+interface TabButtonProps {
+  text: string;
+  name: string;
+  selected: string;
+  onClick: React.MouseEventHandler;
+}
+
+const TabButton: React.FC<TabButtonProps> = ({ name, text, selected, onClick }) => (
+  <button
+    type="button"
+    name={name}
+    onClick={onClick}
+    className={`TabButton ${selected === name ? 'selected' : ''}`}
+  >
+    {text}
+  </button>
+);
+
+export default TabButton;

--- a/src/components/pages/InterviewIntroPage/InterviewHistory.tsx
+++ b/src/components/pages/InterviewIntroPage/InterviewHistory.tsx
@@ -1,0 +1,5 @@
+const InterviewHistory = () => (
+  <div className="InterviewHistory">내 모의 면접 기록을 확인하는 컴포넌트</div>
+);
+
+export default InterviewHistory;

--- a/src/components/pages/InterviewIntroPage/InterviewIntroPage.css
+++ b/src/components/pages/InterviewIntroPage/InterviewIntroPage.css
@@ -1,0 +1,45 @@
+.InterviewOrganization {
+  background-color: rgb(200, 200, 200);
+
+  height: 500px;
+}
+
+.InterviewOrganization > h1 {
+  margin: 0 0 10px 10px;
+}
+
+.InterviewOrganization > p {
+  margin: 0 0 10px 10px;
+}
+
+.InterviewOrganization > select {
+  width: 200px;
+  margin: 0 10px 10px 10px;
+}
+
+.InterviewOrganization > button {
+  margin: 0 0 0 10px;
+}
+
+.InterviewOrganization > .ContentList {
+  display: flex;
+  margin: 0 0 10px 10px;
+}
+
+.InterviewOrganization > .ContentList > button {
+  margin: 0 10px 0 0;
+  color: black;
+  background-color: white;
+  border-radius: 10px;
+}
+
+.InterviewOrganization > .ContentList > button:hover {
+  color: red;
+  background-color: white;
+}
+
+.InterviewHistory {
+  background-color: rgb(200, 200, 200);
+
+  height: 500px;
+}

--- a/src/components/pages/InterviewIntroPage/InterviewIntroPage.tsx
+++ b/src/components/pages/InterviewIntroPage/InterviewIntroPage.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import TabButton from '@components/layout/TabButton/TabButton';
+import InterviewOrganization from '@components/pages/InterviewIntroPage/InterviewOrganization';
+import InterviewHistory from '@components/pages/InterviewIntroPage/InterviewHistory';
+
+import './InterviewIntroPage.css';
+
+interface contentInterface {
+  [key: string]: React.ReactElement;
+}
+
+const InterviewIntroPage = () => {
+  const [selectedTab, setSelectedTab] = useState('InterviewOrganization');
+
+  const handleClickTabButton = (e: React.MouseEvent) => {
+    const { name } = e.target as HTMLButtonElement;
+    setSelectedTab(name);
+  };
+
+  const contents: contentInterface = {
+    // 전환할 탭에서 보여줄 콘텐츠 컴포넌트 목록
+    InterviewOrganization: <InterviewOrganization />,
+    InterviewHistory: <InterviewHistory />,
+  };
+
+  return (
+    <div>
+      <div>
+        <TabButton
+          name="InterviewOrganization"
+          text="모의 면접 구성하기"
+          selected={selectedTab}
+          onClick={handleClickTabButton}
+        />
+        <TabButton
+          name="InterviewHistory"
+          text="내 모의 면접 기록"
+          selected={selectedTab}
+          onClick={handleClickTabButton}
+        />
+      </div>
+      {contents[selectedTab]}
+    </div>
+  );
+};
+
+export default InterviewIntroPage;

--- a/src/components/pages/InterviewIntroPage/InterviewOrganization.tsx
+++ b/src/components/pages/InterviewIntroPage/InterviewOrganization.tsx
@@ -1,0 +1,104 @@
+import { ChangeEvent, useState } from 'react';
+
+import SelectBox from '@components/layout/SelectBox/SelectBox';
+
+interface Content {
+  category: string;
+  topic: string;
+}
+
+const InterviewOrganization = () => {
+  const [selectedCategory, setSelectedCategory] = useState<string>('');
+  const [selectedTopic, setSelectedTopic] = useState<string>('');
+  const [selectedContentList, setSelectedContentList] = useState<Content[]>([]);
+
+  const categoryList = [
+    { value: '', name: '-- 카테고리 선택 --' },
+    { value: '네트워크', name: '네트워크' },
+    { value: '데이터베이스', name: '데이터베이스' },
+  ];
+
+  const topicList = [
+    { value: '', name: '-- 주제 선택 --' },
+    { value: 'HTTP', name: 'HTTP' },
+    { value: 'JPA', name: 'JPA' },
+  ];
+
+  const handleCategoryChange = (e: ChangeEvent) => {
+    const { value } = e.target as HTMLOptionElement;
+    setSelectedCategory(value);
+    // todo: 첫번째 SelectBox 값에 따라서 두번째 Topic SelectBox를 변경한다.
+  };
+
+  const handleTopicChange = (e: ChangeEvent) => {
+    const { value } = e.target as HTMLOptionElement;
+    setSelectedTopic(value);
+  };
+
+  const handleContentAddButton = () => {
+    const newContent: Content = {
+      category: selectedCategory,
+      topic: selectedTopic,
+    };
+
+    if (!newContent.category || !newContent.topic) return;
+
+    if (
+      !selectedContentList.find((content) => JSON.stringify(content) === JSON.stringify(newContent))
+    )
+      setSelectedContentList([...selectedContentList, newContent]);
+  };
+
+  const handleContentDeleteButton = (e: React.MouseEvent) => {
+    const { innerText } = e.target as HTMLButtonElement;
+    const temp = innerText.split(' - ');
+    const deleteContent: Content = { category: temp[0], topic: temp[1] };
+
+    setSelectedContentList(
+      selectedContentList.filter(
+        (content) => JSON.stringify(content) !== JSON.stringify(deleteContent),
+      ),
+    );
+  };
+
+  const handleInterviewStartButton = () => {
+    // todo: selectedContentList 정보를 서버에 전달해서 모의 면접을 시작한다.
+    // console.log(selectedContentList);
+  };
+
+  return (
+    <div className="InterviewOrganization">
+      <br />
+      <h1>직접 선택하여 구성하기</h1>
+      <p>기술 카테고리를 선택하여 면접 내용을 직접 구성합니다.</p>
+
+      <SelectBox
+        optionList={categoryList}
+        value={selectedCategory}
+        onChange={handleCategoryChange}
+      />
+      <SelectBox optionList={topicList} value={selectedTopic} onChange={handleTopicChange} />
+
+      <button type="button" onClick={handleContentAddButton}>
+        추가하기
+      </button>
+
+      <br />
+      <br />
+      <h1>현재 면접 구성</h1>
+      <p>모의 기술 면접에서 다음과 같은 내용들이 질문으로 나올 수 있습니다.</p>
+      <div className="ContentList">
+        {selectedContentList.map((content) => (
+          <button type="button" onClick={handleContentDeleteButton}>
+            {content.category} - {content.topic}
+          </button>
+        ))}
+      </div>
+      <button type="button" onClick={handleInterviewStartButton}>
+        모의 면접 시작하기
+      </button>
+    </div>
+  );
+};
+
+export default InterviewOrganization;


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-105](https://soma-til.atlassian.net/browse/TIL-105)

<br>

## 개요

![1](https://github.com/user-attachments/assets/188e789d-52e3-4dc2-a568-57535fd762ab)
- 모의 기술 면접 구성 화면 작성

<br>

## 내용

https://github.com/user-attachments/assets/9b1b3268-70c2-4dbb-a0a9-052efb2b8495


- TabButton 컴포넌트 코드 작성 (메인 콘텐츠 화면 내부에서 탭을 이동할 수 있는 버튼)
- SelectBox 컴포넌트 코드 작성 (select-option 드랍다운)
- InterviewIntroPage 코드 작성 (모의 면접 구성/기록 화면)
- InterviewOrganization 컴포넌트 코드 작성 (모의 면접 구성 컴포넌트)
<br>

- 추후 구현해야 할 부분
  - 2중 SelectBox 구현 (뒤의 SelectBox가 앞의 SelectBox 영향 받도록)
  - 서버에서 데이터를 받아오는 부분
  - 면접 시작 버튼 클릭 시 면접을 생성하고, 페이지를 이동하는 부분

<br>

## 리뷰어한테 할 말

- 개발 단계 동안 임시로 InterviewIntroPage를 인가 없이 접근 가능하게 작성해두었습니다.

[TIL-105]: https://soma-til.atlassian.net/browse/TIL-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ