### PR TITLE
[TIL-118] Private Route 인가 로직 on/off 기능 구현

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,4 @@
 # - 설정한 환경 변수는 코드에서 'process.env.REACT_APP_...' 형태로 전역에서 접근 접근 가능
 REACT_APP_PROFILE=${환경 설정 프로필}      # ex) local
 REACT_APP_TIL_API_URL=${TIL API 주소}   # ex) http://localhost:8080
+REACT_APP_AUTH_MODE_DISABLED=${인증 모드 비활성화 여부} # url로 접근할 때 인증을 거치지 않고 접근할 수 있도록 설정 ex) true(인증 모드 off), false(기본값, 인증 모드 on)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,12 +16,10 @@ const App: React.FC = () => (
       <Route path="/" element={<div>메인페이지</div>} />
       <Route path="/problem" element={<div>기술학습</div>} />
 
-      {/* 인증 여부 상관 없이 접속 가능한 페이지: 개발 단계동안만 임시로 올려두는 페이지 */}
-      <Route path="/interview" element={<InterviewIntroPage />} />
-
       {/* 인증이 필요한 페이지 정의 */}
       <Route element={<PrivateRoute />}>
         <Route path="/mypage" element={<div>마이페이지</div>} />
+        <Route path="/interview" element={<InterviewIntroPage />} />
       </Route>
       {/* 인증을 하지 않아야만 접속 가능한 페이지 정의 */}
       <Route element={<PrivateRoute authentication={false} />}>

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -7,6 +7,14 @@ interface PrivateRouteProps {
 
 const PrivateRoute = ({ authentication = true }: PrivateRouteProps): React.ReactElement | null => {
   const { isAuthenticated } = useAuthStore();
+
+  if (
+    process.env.REACT_APP_PROFILE !== 'prod' &&
+    process.env.REACT_APP_AUTH_MODE_DISABLED === 'true'
+  ) {
+    return <Outlet />;
+  }
+
   if (authentication) {
     return isAuthenticated ? <Outlet /> : <Navigate to="/login" />;
   }


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-118](https://soma-til.atlassian.net/browse/TIL-118)

<br>

## 개요
Private Route 인가 로직 on/off 기능 구현
- 목적 : 화면 개발 편의성을 위해 로그인 없이도 개발하고 있는 페이지에 접근할 수 있고자 함

<br>

## 내용
- 환경 변수 `REACT_APP_AUTH_MODE_DISABLED` 를 통해 인증 모드 설정
  - `true`: 인증 비활성 모드
  - `false` or `환경 변수 세팅 X` : 인증 활성 모드(기존과 동일)
- 인증 비활성 모드시 url로 개발하고 있는 페이지에 접근할 때 인증을 거치지 않고 접근할 수 있도록 설정 
  <img width="500" alt="image" src="https://github.com/user-attachments/assets/0b97d5e2-c45c-46e2-a3d4-9028e94f7e83">


<br>

## 리뷰어한테 할 말
😀

[TIL-118]: https://soma-til.atlassian.net/browse/TIL-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ