### PR TITLE
[TIL-122] Main 컴포넌트 레이아웃 추가

### DIFF
--- a/src/components/layout/Main/Main.css
+++ b/src/components/layout/Main/Main.css
@@ -1,0 +1,5 @@
+.Main {
+  padding: 20px 0px;
+
+  flex: 1;
+}

--- a/src/components/layout/Main/Main.tsx
+++ b/src/components/layout/Main/Main.tsx
@@ -1,0 +1,9 @@
+import './Main.css';
+
+const Main = (props: { children: React.ReactNode }) => {
+  const { children } = props;
+
+  return <main className="Main">{children}</main>;
+};
+
+export default Main;

--- a/src/components/layout/PageLayout.css
+++ b/src/components/layout/PageLayout.css
@@ -3,9 +3,3 @@
   flex-direction: column;
   min-height: 100vh;
 }
-
-.PageLayout > main {
-  padding: 20px 0px;
-
-  flex: 1;
-}

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -1,4 +1,5 @@
 import Header from '@components/layout/Header/Header';
+import Main from '@components/layout/Main/Main';
 import Footer from '@components/layout/Footer/Footer';
 
 import './PageLayout.css';
@@ -9,7 +10,7 @@ const PageLayout = (props: { children: React.ReactNode }) => {
   return (
     <div className="PageLayout">
       <Header />
-      <main>{children}</main>
+      <Main>{children}</Main>
       <Footer />
     </div>
   );


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-122](https://soma-til.atlassian.net/browse/TIL-122)

<br>

## 개요

Main 컴포넌트 레이아웃 추가

<br>

## 내용

- 기존 `<main> {children} </main>` 으로만 감싸두었던 메인 콘텐츠 부분을 Main 컴포넌트를 작성하여 포함

<br>

## 리뷰어한테 할 말

🌵


[TIL-122]: https://soma-til.atlassian.net/browse/TIL-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ