### PR TITLE
[FEAT/TIL-138] 모의 면접 구성 화면 에러 처리 추가

### DIFF
--- a/src/components/pages/InterviewIntroPage/InterviewOrganization.tsx
+++ b/src/components/pages/InterviewIntroPage/InterviewOrganization.tsx
@@ -4,6 +4,7 @@ import { getCategoryList } from '@services/api/categoryService';
 import SelectBox, { Option } from '@components/layout/SelectBox/SelectBox';
 
 import { Category } from '@type/category';
+import { showAlertPopup } from '@utils/showPopup';
 
 const InterviewOrganization = () => {
   const categoryList = useRef<Category[]>([]);
@@ -38,12 +39,14 @@ const InterviewOrganization = () => {
           nameList.current = uniqueNameList;
         })
         .then(() => {
+          const curName = nameList.current.length ? nameList.current[0].name : '';
+
           setSelectedCategory({
-            name: nameList.current[0].name,
+            name: curName,
             topic: '',
           });
 
-          return nameList.current[0].name;
+          return curName;
         })
         .then((curName) => {
           const uniqueTopicList = categoryList.current
@@ -61,11 +64,14 @@ const InterviewOrganization = () => {
           return { curName, uniqueTopicList };
         })
         .then(({ curName, uniqueTopicList }) => {
+          const curTopic = uniqueTopicList.length ? uniqueTopicList[0].name : '';
+
           setSelectedCategory({
             name: curName,
-            topic: uniqueTopicList[0].name,
+            topic: curTopic,
           });
-        });
+        })
+        .catch((error) => showAlertPopup(error.message));
     };
     getData();
   }, []);
@@ -85,9 +91,11 @@ const InterviewOrganization = () => {
 
     setTopicList(uniqueTopicList);
 
+    const curTopic = uniqueTopicList.length ? uniqueTopicList[0].name : '';
+
     setSelectedCategory({
       name: value,
-      topic: uniqueTopicList[0].name,
+      topic: curTopic,
     });
   };
 


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-138](https://soma-til.atlassian.net/browse/TIL-138)

<br>

## 개요

- 모의 면접 구성 화면 에러 처리 추가

<br>

## 내용

![1](https://github.com/user-attachments/assets/5ba279b9-f9e3-4550-9c4a-26b097441d5f)
- axios 통신으로 카테고리 리스트 받아오지 못하면 에러 처리 추가
- `name` 프로퍼티 읽어오는 것 관련한 에러 처리 추가

<br>

## 리뷰어한테 할 말

👀


[TIL-138]: https://soma-til.atlassian.net/browse/TIL-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ