### PR TITLE
[TIL-101] 기술학습 상세 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import JoinPage from '@components/pages/JoinPage/JoinPage';
 import LoginPage from '@components/pages/LoginPage/LoginPage';
 import InterviewIntroPage from '@components/pages/InterviewIntroPage/InterviewIntroPage';
 import ProblemListPage from '@components/pages/ProblemListPage/ProblemListPage';
+import ProblemDetailPage from '@components/pages/ProblemDetailPage/ProblemDetailPage';
 import GlobalStyle from '@styles/GlobalStyle';
 
 import PrivateRoute from './route';
@@ -19,7 +20,7 @@ const App: React.FC = () => (
         {/* 인증 여부 상관 없이 접속 가능한 페이지 정의 */}
         <Route path="/" element={<MainPage />} />
         <Route path="/problem" element={<ProblemListPage />} />
-
+        <Route path="/problem/:id" element={<ProblemDetailPage />} />
         {/* 인증이 필요한 페이지 정의 */}
         <Route element={<PrivateRoute />}>
           <Route path="/mypage" element={<div>마이페이지</div>} />

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
@@ -1,0 +1,80 @@
+import { DISPLAY_HEIGHT_WITHOUT_HEADER } from '@styles/length';
+import { Button } from '@styles/ButtonStyle';
+import styled from 'styled-components';
+import { Input } from 'antd';
+
+const { TextArea } = Input;
+
+export const ProblemDetailContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  position: relative;
+  min-height: ${DISPLAY_HEIGHT_WITHOUT_HEADER};
+`;
+
+export const ProblemInfoBar = styled.div`
+  display: flex;
+  flex: 0.1;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+`;
+
+export const Title = styled.h1`
+  // 스타일링 추가
+`;
+
+export const Category = styled.div`
+  // 스타일링 추가
+`;
+
+export const ProblemInfo = styled.div`
+  // 스타일링 추가
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex: 0.8;
+  overflow: auto;
+`;
+
+export const QuestionSection = styled.div`
+  width: 40%;
+  background: #f0f0f0;
+  padding: 20px;
+  overflow-y: auto;
+`;
+
+export const AnswerSection = styled.div`
+  width: 60%;
+  overflow-y: auto;
+`;
+
+export const Question = styled.div`
+  padding: 5px;
+`;
+
+export const BottomBar = styled.div`
+  display: flex;
+  flex: 0.1;
+  justify-content: space-between;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+`;
+
+export const CustomButton = styled(Button)`
+  width: 150px;
+  height: 50px;
+  font-size: 14px;
+`;
+
+export const TextDiv = styled.div`
+  padding: 10px;
+`;
+
+export const StyledTextArea = styled(TextArea)`
+  resize: none;
+`;

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
@@ -65,10 +65,22 @@ export const BottomBar = styled.div`
   width: 100%;
 `;
 
+export const ButtonGroup = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
 export const CustomButton = styled(Button)`
   width: 150px;
   height: 50px;
   font-size: 14px;
+`;
+
+export const CustomLoginButton = styled(Button)`
+  width: 150px;
+  height: 50px;
+  font-size: 14px;
+  margin-left: auto;
 `;
 
 export const TextDiv = styled.div`

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getProblemDetail, solveProblem } from '@services/api/problemService';
+import { ProblemDetailInfo } from '@type/problem';
+import { Tabs, Modal } from 'antd';
+import {
+  ProblemDetailContainer,
+  ProblemInfoBar,
+  ProblemInfo,
+  Title,
+  Category,
+  Question,
+  BottomBar,
+  ContentContainer,
+  QuestionSection,
+  AnswerSection,
+  CustomButton,
+  StyledTextArea,
+  TextDiv,
+} from './ProblemDetailPage.style';
+
+const { TabPane } = Tabs;
+
+const ProblemDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [problemDetail, setProblemDetail] = useState<ProblemDetailInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [answer, setAnswer] = useState<string>('');
+  const [result, setResult] = useState<string | null>(null);
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  useEffect(() => {
+    const fetchProblemDetail = async () => {
+      try {
+        const response = await getProblemDetail(id!);
+        setProblemDetail(response.result?.problemInfo || null);
+      } catch (err) {
+        setError('An error occurred while fetching problem info.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProblemDetail();
+  }, [id]);
+
+  const handleSubmit = async () => {
+    if (answer.trim() === '') {
+      alert('답변을 입력해주세요.');
+      return;
+    }
+
+    try {
+      const response = await solveProblem(id!, answer);
+      console.log('API Response:', response);
+      setResult(`Status: ${response.result?.problemResult?.status}`);
+      setIsModalVisible(true);
+    } catch (err) {
+      setError('답변이 제출되지 않았습니다. 다시 시도해주세요.');
+    }
+  };
+
+  const handleModalClose = () => {
+    setIsModalVisible(false);
+    setResult(null);
+  };
+
+  const handleReset = () => {
+    setAnswer('');
+  };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
+  return (
+    // todo: 사이드바 사이즈 조절 가능허도록 수정 예정, 내 답변 기록 데이터 추가 예정 (API 필요), 스타일 수정 예정
+    <ProblemDetailContainer>
+      <ProblemInfoBar>
+        <Title>{problemDetail && problemDetail.title}</Title>
+        <Category>
+          {problemDetail?.categoryName || '네트워크'} | {problemDetail?.topic || 'HTTP'}
+        </Category>
+        <ProblemInfo>난이도: {problemDetail?.level}</ProblemInfo>
+        <ProblemInfo>완료한 사람: {problemDetail?.solved}명</ProblemInfo>
+        <ProblemInfo>정답률: {problemDetail?.percentage}%</ProblemInfo>
+      </ProblemInfoBar>
+      <ContentContainer>
+        <QuestionSection>
+          <h3>문제 설명</h3>
+          <Question>{problemDetail?.question}</Question>
+        </QuestionSection>
+        <AnswerSection>
+          <Tabs defaultActiveKey="1" type="card">
+            <TabPane tab="답변" key="1">
+              <TextDiv>
+                <StyledTextArea
+                  value={answer}
+                  onChange={(e) => setAnswer(e.target.value)}
+                  rows={25}
+                  placeholder="답변을 입력하세요."
+                />
+              </TextDiv>
+            </TabPane>
+            <TabPane tab="내 답변 기록" key="2">
+              <div>내 답변 기록</div>
+            </TabPane>
+          </Tabs>
+        </AnswerSection>
+      </ContentContainer>
+      <BottomBar>
+        <CustomButton>질문하기</CustomButton>
+        <CustomButton>다른 사람의 답변</CustomButton>
+        <CustomButton onClick={handleReset}>답변 초기화</CustomButton>
+        <CustomButton onClick={handleSubmit}>제출</CustomButton>
+      </BottomBar>
+      <Modal
+        title="채점 결과"
+        visible={isModalVisible}
+        footer={[
+          <CustomButton key="back" onClick={handleModalClose}>
+            내 답변 보러가기
+          </CustomButton>,
+        ]}
+        onCancel={handleModalClose}
+      >
+        <p>{result}</p>
+      </Modal>
+    </ProblemDetailContainer>
+  );
+};
+
+export default ProblemDetailPage;

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { getProblemDetail, solveProblem } from '@services/api/problemService';
 import { ProblemDetailInfo } from '@type/problem';
 import { Tabs, Modal } from 'antd';
 import { showAlertPopup } from '@utils/showPopup';
+import useAuthStore from '@store/useAuthStore';
 import {
   ProblemDetailContainer,
   ProblemInfoBar,
@@ -16,8 +17,10 @@ import {
   QuestionSection,
   AnswerSection,
   CustomButton,
+  CustomLoginButton,
   StyledTextArea,
   TextDiv,
+  ButtonGroup,
 } from './ProblemDetailPage.style';
 
 const { TabPane } = Tabs;
@@ -30,6 +33,12 @@ const ProblemDetailPage: React.FC = () => {
   const [answer, setAnswer] = useState<string>('');
   const [result, setResult] = useState<string | null>(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const { isAuthenticated, checkAuthentication } = useAuthStore();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    checkAuthentication();
+  }, [checkAuthentication]);
 
   useEffect(() => {
     const fetchProblemDetail = async () => {
@@ -70,6 +79,10 @@ const ProblemDetailPage: React.FC = () => {
     setAnswer('');
   };
 
+  const handleLoginRedirect = () => {
+    navigate('/login');
+  };
+
   if (loading) {
     return <div>Loading...</div>;
   }
@@ -104,20 +117,31 @@ const ProblemDetailPage: React.FC = () => {
                   onChange={(e) => setAnswer(e.target.value)}
                   rows={25}
                   placeholder="답변을 입력하세요."
+                  disabled={!isAuthenticated}
                 />
               </TextDiv>
             </TabPane>
-            <TabPane tab="내 답변 기록" key="2">
+            <TabPane tab="내 답변 기록" key="2" disabled={!isAuthenticated}>
               <div>내 답변 기록</div>
             </TabPane>
           </Tabs>
         </AnswerSection>
       </ContentContainer>
       <BottomBar>
-        <CustomButton>질문하기</CustomButton>
-        <CustomButton>다른 사람의 답변</CustomButton>
-        <CustomButton onClick={handleReset}>답변 초기화</CustomButton>
-        <CustomButton onClick={handleSubmit}>제출</CustomButton>
+        {!isAuthenticated ? (
+          <CustomLoginButton onClick={handleLoginRedirect}>로그인하기</CustomLoginButton>
+        ) : (
+          <>
+            <ButtonGroup>
+              <CustomButton>질문하기</CustomButton>
+              <CustomButton>다른 사람의 답변</CustomButton>
+            </ButtonGroup>
+            <ButtonGroup>
+              <CustomButton onClick={handleReset}>답변 초기화</CustomButton>
+              <CustomButton onClick={handleSubmit}>제출</CustomButton>
+            </ButtonGroup>
+          </>
+        )}
       </BottomBar>
       <Modal
         title="채점 결과"

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { getProblemDetail, solveProblem } from '@services/api/problemService';
 import { ProblemDetailInfo } from '@type/problem';
 import { Tabs, Modal } from 'antd';
+import { showAlertPopup } from '@utils/showPopup';
 import {
   ProblemDetailContainer,
   ProblemInfoBar,
@@ -33,7 +34,7 @@ const ProblemDetailPage: React.FC = () => {
   useEffect(() => {
     const fetchProblemDetail = async () => {
       try {
-        const response = await getProblemDetail(id!);
+        const response = await getProblemDetail(id ?? '');
         setProblemDetail(response.result?.problemInfo || null);
       } catch (err) {
         setError('An error occurred while fetching problem info.');
@@ -47,13 +48,12 @@ const ProblemDetailPage: React.FC = () => {
 
   const handleSubmit = async () => {
     if (answer.trim() === '') {
-      alert('답변을 입력해주세요.');
+      showAlertPopup('답변을 입력해주세요.');
       return;
     }
 
     try {
-      const response = await solveProblem(id!, answer);
-      console.log('API Response:', response);
+      const response = await solveProblem(id ?? '', answer);
       setResult(`Status: ${response.result?.problemResult?.status}`);
       setIsModalVisible(true);
     } catch (err) {

--- a/src/components/pages/ProblemListPage/ProblemListPage.tsx
+++ b/src/components/pages/ProblemListPage/ProblemListPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getProblemList } from '@services/api/problemService';
 import { ProblemListInfo } from '@type/problem';
 import { Pagination, Table } from 'antd';
@@ -48,6 +49,7 @@ const ProblemListPage: React.FC = () => {
   const [problemList, setProblemList] = useState<ProblemListInfo[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchProblemList = async () => {
@@ -64,6 +66,9 @@ const ProblemListPage: React.FC = () => {
     fetchProblemList();
   }, []);
 
+  const onRowClick = (record: ProblemListInfo) => {
+    navigate(`/problem/${record.id}`);
+  };
   if (loading) {
     return <div>Loading...</div>;
   }
@@ -71,7 +76,7 @@ const ProblemListPage: React.FC = () => {
     return <div>{error}</div>;
   }
   return (
-    // todo: 검색, 페이징, 상세화면 라우팅 가능 추가 예정
+    // todo: 검색, 페이징 기능 추가 예정
     <ProblemPageContainer>
       <SubTitle>기술학습</SubTitle>
       <SearchBar />
@@ -79,7 +84,15 @@ const ProblemListPage: React.FC = () => {
         <div>문제가 없습니다.</div>
       ) : (
         <>
-          <Table columns={columns} dataSource={problemList} rowKey="id" pagination={false} />
+          <Table
+            columns={columns}
+            dataSource={problemList}
+            rowKey="id"
+            pagination={false}
+            onRow={(record) => ({
+              onClick: () => onRowClick(record),
+            })}
+          />
           <Pagination align="center" defaultCurrent={1} total={50} />
         </>
       )}

--- a/src/services/api/problemService.ts
+++ b/src/services/api/problemService.ts
@@ -1,6 +1,6 @@
 import apiClient from '@services/api/axios';
 import { ApiResponse } from '@type/api';
-import { ProblemListInfo } from '@type/problem';
+import { ProblemListInfo, ProblemDetailInfo } from '@type/problem';
 
 export interface ProblemListData {
   items: ProblemListInfo[];
@@ -12,7 +12,31 @@ export interface ProblemListData {
   };
 }
 
+export interface ProblemDetailData {
+  problemInfo: ProblemDetailInfo;
+}
+
+export interface SolveProblemData {
+  problemResult: {
+    status: string;
+    solution: string;
+  };
+}
+
 export const getProblemList = async (): Promise<ApiResponse<ProblemListData>> => {
   const response = await apiClient.get('/problem');
+  return response.data;
+};
+
+export const getProblemDetail = async (id: string): Promise<ApiResponse<ProblemDetailData>> => {
+  const response = await apiClient.get(`/problem/${id}`);
+  return response.data;
+};
+
+export const solveProblem = async (
+  id: string,
+  answer: string,
+): Promise<ApiResponse<SolveProblemData>> => {
+  const response = await apiClient.post(`/problem/${id}/solve`, { answer });
   return response.data;
 };

--- a/src/type/problem.d.ts
+++ b/src/type/problem.d.ts
@@ -7,3 +7,16 @@ export interface ProblemListInfo {
   categoryName: string | null;
   topic: string | null;
 }
+
+export interface ProblemDetailInfo {
+  id: number;
+  title: string;
+  question: string;
+  solution: string;
+  point: number;
+  level: number;
+  solved: number;
+  percentage: number;
+  categoryName: string | null;
+  topic: string | null;
+}


### PR DESCRIPTION

## 이슈 번호(링크)

[TIL-101](https://soma-til.atlassian.net/browse/TIL-101)

<br>

## 개요

- 기술학습 상세 페이지 구현

<br>

## 내용

- 리스트에서 상세페이지로 라우팅 기능 추가
- 상세 정보 GET & 답변 POST
- 채점 결과 모달로 띄우기
- 로그인 여부에 따른 접근 제한 및 버튼 수정 

https://github.com/user-attachments/assets/7ae9f75d-8909-4332-97ea-58240ee46c83



<br>


## 리뷰어한테 할 말

- 문제 영역과 풀이 영역 사이즈 조절이 가능하도록 구현하려고 했는데.. 잘 되지 않아서 추후 기능 추가하도록 하겠습니다. 
- 그 외에 추가할 부분 있으면 말씀해주세요🙂 

[TIL-101]: https://soma-til.atlassian.net/browse/TIL-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ