### PR TITLE
[TIL-144] toast 메시지창 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 
+import { ToastProvider } from '@components/common/notification/ToastProvider';
 import BasicPageLayout from '@components/layout/BasicPageLayout';
 import MainPage from '@components/pages/MainPage/MainPage';
 import JoinPage from '@components/pages/JoinPage/JoinPage';
@@ -13,7 +14,7 @@ import GlobalStyle from '@styles/GlobalStyle';
 import PrivateRoute from './route';
 
 const App: React.FC = () => (
-  <>
+  <ToastProvider>
     <GlobalStyle />
     <BasicPageLayout>
       <Routes>
@@ -33,7 +34,7 @@ const App: React.FC = () => (
         </Route>
       </Routes>
     </BasicPageLayout>
-  </>
+  </ToastProvider>
 );
 
 export default App;

--- a/src/components/common/notification/ToastProvider.tsx
+++ b/src/components/common/notification/ToastProvider.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, ReactNode, useMemo, useCallback } from 'react';
+import { notification } from 'antd';
+import { TOAST_POS, TOAST_TYPE } from '@constants/toast';
+
+interface ToastProviderProps {
+  children: ReactNode;
+}
+
+interface ToastOptions {
+  message: string; // 알림창 제목
+  description: string; // 알림창 내용
+  type?: (typeof TOAST_TYPE)[keyof typeof TOAST_TYPE]; // 알림창 유형
+  duration?: number; // 알림창 노출 시간
+  placement?: (typeof TOAST_POS)[keyof typeof TOAST_POS]; // 알림창 위치
+}
+
+interface ToastContextType {
+  notify: (options: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
+  const notify = useCallback(
+    ({
+      message,
+      description,
+      type = TOAST_TYPE.OPEN,
+      duration = 2,
+      placement = TOAST_POS.TOP,
+    }: ToastOptions): void => {
+      notification[type]({
+        message,
+        description,
+        duration,
+        placement,
+      });
+    },
+    [],
+  );
+
+  const value = useMemo(() => ({ notify }), [notify]);
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+};
+
+export const useToast = (): ToastContextType => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};

--- a/src/components/pages/JoinPage/JoinPage.tsx
+++ b/src/components/pages/JoinPage/JoinPage.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
+import { useToast } from '@components/common/notification/ToastProvider';
+import { TOAST_POS, TOAST_TYPE } from '@constants/toast';
 import { JoinData, checkNickname, join } from '@services/api/userService';
-import { alertError, getErrorMessage } from '@utils/errorHandler';
-import { showAlertPopup } from '@utils/showPopup';
+import { getErrorMessage } from '@utils/errorHandler';
 import { HalfWidthDiv } from '@styles/DivStyle';
 import { PRIMARY_PURPLE } from '@styles/pallete';
 import { DISPLAY_HEIGHT_WITHOUT_HEADER } from '@styles/length';
@@ -20,6 +21,7 @@ import { EMAIL, NICKNAME, PASSWORD, CONFIRM_PASSWORD } from '@utils/userInfo';
 
 const JoinPage: React.FC = () => {
   const navigate = useNavigate();
+  const { notify } = useToast();
   const {
     register,
     trigger,
@@ -30,10 +32,20 @@ const JoinPage: React.FC = () => {
   const onSubmit: SubmitHandler<JoinData> = async (data: JoinData) => {
     try {
       await join(data);
-      showAlertPopup('회원가입 성공');
+      notify({
+        message: '회원가입 성공',
+        description: '로그인 페이지로 이동합니다.',
+        type: TOAST_TYPE.SUCCESS,
+        placement: TOAST_POS.TOP_RIGHT,
+      });
       navigate('/login');
     } catch (err) {
-      alertError(err);
+      notify({
+        message: '회원가입 실패',
+        description: getErrorMessage(err),
+        type: TOAST_TYPE.ERROR,
+        placement: TOAST_POS.BOTTOM_RIGHT,
+      });
     }
   };
 

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -1,0 +1,20 @@
+// antd notification 참고: https://ant.design/components/notification#api
+
+// 알림창 유형
+export const TOAST_TYPE = {
+  SUCCESS: 'success' as const,
+  INFO: 'info' as const,
+  WARNING: 'warning' as const,
+  ERROR: 'error' as const,
+  OPEN: 'open' as const,
+} as const;
+
+// 알림창 위치
+export const TOAST_POS = {
+  TOP: 'top' as const,
+  TOP_RIGHT: 'topRight' as const,
+  TOP_LEFT: 'topLeft' as const,
+  BOTTOM: 'bottom' as const,
+  BOTTOM_RIGHT: 'bottomRight' as const,
+  BOTTOM_LEFT: 'bottomLeft' as const,
+} as const;


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-144](https://soma-til.atlassian.net/browse/TIL-144)

<br>

## 개요
toast 메시지창 설정

<br>

## 내용
- toast 메시지창 설정
- 기존 회원가입 alert창 toast창으로 변경

https://github.com/user-attachments/assets/b9146a9d-b952-4feb-9c8f-dd4723e55f60



<br>

## 리뷰어한테 할 말
- 기본 toast 메시지 창 설정은 아래와 같이 설정했습니다!
  - 타입 : open
  - 노출 시간 :2초
  - 알림창 위치 : 상단 가운데
- 추가 옵션 설정 관련 참고 : [antd notification](https://ant.design/components/notification#api)


[TIL-144]: https://soma-til.atlassian.net/browse/TIL-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ