### PR TITLE
[TIL-163] 이미지 경로 절대경로로 수정

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -29,7 +29,7 @@ const Header: React.FC = () => {
     <HeaderArea>
       <Section pos="left">
         <Logo onClick={handleHomeButton}>
-          <img src="images/TIL_logo.png" alt="TIL_logo" />
+          <img src="/images/TIL_logo.png" alt="TIL_logo" />
         </Logo>
       </Section>
 

--- a/src/components/layout/Header/HeaderMenuItem.tsx
+++ b/src/components/layout/Header/HeaderMenuItem.tsx
@@ -33,7 +33,7 @@ export const HeaderLogoutButton: React.FC<HeaderMenuButtonProps> = ({ title, pat
 
   return (
     <LogoutButton onClick={handleButton}>
-      <img src="images/logout_icon.png" alt="logout" /> {title}
+      <img src="/images/logout_icon.png" alt="logout" /> {title}
     </LogoutButton>
   );
 };

--- a/src/components/pages/MainPage/MainPage.tsx
+++ b/src/components/pages/MainPage/MainPage.tsx
@@ -6,7 +6,7 @@ import { Banner, BannerContainer } from './MainPage.style';
 const MainPage: React.FC = () => (
   <BasicPageLayout showFooter>
     <BannerContainer>
-      <Banner src="images/banner.png" alt="banner" />
+      <Banner src="/images/banner.png" alt="banner" />
     </BannerContainer>
   </BasicPageLayout>
 );


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-163](https://soma-til.atlassian.net/browse/TIL-163)

<br>

## 개요
이미지 경로 절대경로로 수정
- 문제 상황 : 헤더 영역에 들어간 이미지 중 url path가 두번 들어가면 이미지 경로를 제대로 찾지 못함

<br>

## 내용
- 기존에 정의한 이미지 경로 상대경로에서 절대경로로 수정

<br>

## 리뷰어한테 할 말
💡


[TIL-163]: https://soma-til.atlassian.net/browse/TIL-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ