### PR TITLE
[TIL-127] 모의 면접 생성 로직 POST API 코드 작성

### DIFF
--- a/src/components/pages/InterviewIntroPage/InterviewOrganization.tsx
+++ b/src/components/pages/InterviewIntroPage/InterviewOrganization.tsx
@@ -1,12 +1,16 @@
 import { ChangeEvent, useState, useEffect } from 'react';
-
+import { useNavigate } from 'react-router-dom';
 import { getCategoryList } from '@services/api/categoryService';
 import SelectBox from '@components/layout/SelectBox/SelectBox';
 
 import { Category } from '@type/category';
 import { showAlertPopup } from '@utils/showPopup';
 
+import { createInterview } from '@services/api/InterviewService';
+
 const InterviewOrganization = () => {
+  const navigate = useNavigate();
+
   const [categoryList, setCategoryList] = useState<Category[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<Category>({ id: -1, tag: '' });
   const [selectedCategoryList, setSelectedCategoryList] = useState<Category[]>([]);
@@ -60,11 +64,32 @@ const InterviewOrganization = () => {
   };
 
   const handleInterviewStartButton = () => {
-    // todo: selectedCategoryList 정보를 서버에 전달해서 모의 면접을 시작한다.
-    // const selectedCategoryIdList: number[] = selectedCategoryList.map((category) => category.id);
-    // 모의 면접을 생성하는 POST API
-    // 이후 해당 면접 화면으로 이동
-    // PGR 패턴
+    const selectedCategoryIdList: number[] = selectedCategoryList.map((category) => category.id);
+
+    if (!selectedCategoryIdList.length) {
+      showAlertPopup('카테고리를 최소 1개 이상 선택해주세요.');
+      return;
+    }
+
+    // todo: 카테고리 여러개 선택 가능하도록 구조 변경
+    if (selectedCategoryIdList.length > 1) {
+      showAlertPopup('베타 버전에서 카테고리는 1개만 선택 가능합니다.');
+      return;
+    }
+
+    const promise = createInterview({ categoryIdList: selectedCategoryIdList });
+    const postData = () => {
+      promise
+        .then((data) => {
+          const uuid = data.result?.interviewUuid.uuid;
+          return uuid;
+        })
+        .then((uuid) => {
+          navigate(`/interview/${uuid}`);
+        })
+        .catch((error) => showAlertPopup(error.message));
+    };
+    postData();
   };
 
   return (

--- a/src/services/api/InterviewService.ts
+++ b/src/services/api/InterviewService.ts
@@ -1,0 +1,18 @@
+import apiClient from '@services/api/axios';
+import { ApiResponse } from '@type/api';
+import { InterviewUuid } from '@type/interview';
+
+export interface InterviewCreateData {
+  categoryIdList: number[];
+}
+
+export interface InterviewUuidData {
+  interviewUuid: InterviewUuid;
+}
+
+export const createInterview = async (
+  data: InterviewCreateData,
+): Promise<ApiResponse<InterviewUuidData>> => {
+  const response = await apiClient.post('/interview/create', data);
+  return response.data;
+};

--- a/src/type/interview.d.ts
+++ b/src/type/interview.d.ts
@@ -1,0 +1,3 @@
+export interface InterviewUuid {
+  uuid: string;
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-127](https://soma-til.atlassian.net/browse/TIL-127)

<br>

## 개요

- 모의 면접 생성 로직 POST API 코드 작성

<br>

## 내용

https://github.com/user-attachments/assets/d500236a-7395-4c2e-adcb-e4349ce9ee44


- 모의 면접 생성을 위한 카테고리 선택 개수 제한 추가
- 버튼 클릭 시 POST API 요청을 서버로 보내서 모의 면접 생성 후 고유한 uuid 받아오는 기능 추가
  - 관련 service, type 코드 추가

<br>

## 리뷰어한테 할 말

- 일단 모의 면접을 구성하기 위해서 카테고리는 1개만 선택할 수 있도록 제한했습니다!


[TIL-127]: https://soma-til.atlassian.net/browse/TIL-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ