### PR TITLE
[TIL-173] 기술 학습 문제 상세 화면에 즐겨찾기 기능 추가

### DIFF
--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
@@ -1,7 +1,9 @@
-import { DISPLAY_HEIGHT_WITHOUT_HEADER } from '@styles/length';
-import { Button } from '@styles/ButtonStyle';
 import styled from 'styled-components';
 import { Input } from 'antd';
+
+import { DISPLAY_HEIGHT_WITHOUT_HEADER } from '@styles/length';
+import { Button } from '@styles/ButtonStyle';
+import { BLACK, PRIMARY_PURPLE } from '@styles/pallete';
 
 const { TextArea } = Input;
 
@@ -90,3 +92,21 @@ export const TextDiv = styled.div`
 export const StyledTextArea = styled(TextArea)`
   resize: none;
 `;
+
+export const BookMarkIcon = ({ isFavorite }: { isFavorite: boolean }) => (
+  <svg
+    width="20"
+    height="26"
+    viewBox="0 0 20 26"
+    fill={isFavorite ? PRIMARY_PURPLE : 'none'}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M1.25 7.75C1.25 5.6498 1.25 4.5997 1.65873 3.79754C2.01825 3.09193 2.59193 2.51825 3.29754 2.15873C4.0997 1.75 5.1498 1.75 7.25 1.75H12.75C14.8502 1.75 15.9003 1.75 16.7025 2.15873C17.4081 2.51825 17.9817 3.09193 18.3413 3.79754C18.75 4.5997 18.75 5.6498 18.75 7.75V24.25L10 19.25L1.25 24.25V7.75Z"
+      stroke={isFavorite ? PRIMARY_PURPLE : BLACK}
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
@@ -93,20 +93,32 @@ export const StyledTextArea = styled(TextArea)`
   resize: none;
 `;
 
-export const BookMarkIcon = ({ isFavorite }: { isFavorite: boolean }) => (
-  <svg
-    width="20"
-    height="26"
-    viewBox="0 0 20 26"
-    fill={isFavorite ? PRIMARY_PURPLE : 'none'}
-    xmlns="http://www.w3.org/2000/svg"
+export const BookMarkIcon = ({
+  isFavorite,
+  onClick,
+}: {
+  isFavorite: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-label={isFavorite ? '즐겨찾기 제거' : '즐겨찾기 추가'}
   >
-    <path
-      d="M1.25 7.75C1.25 5.6498 1.25 4.5997 1.65873 3.79754C2.01825 3.09193 2.59193 2.51825 3.29754 2.15873C4.0997 1.75 5.1498 1.75 7.25 1.75H12.75C14.8502 1.75 15.9003 1.75 16.7025 2.15873C17.4081 2.51825 17.9817 3.09193 18.3413 3.79754C18.75 4.5997 18.75 5.6498 18.75 7.75V24.25L10 19.25L1.25 24.25V7.75Z"
-      stroke={isFavorite ? PRIMARY_PURPLE : BLACK}
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
+    <svg
+      width="20"
+      height="26"
+      viewBox="0 0 20 26"
+      fill={isFavorite ? PRIMARY_PURPLE : 'none'}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1.25 7.75C1.25 5.6498 1.25 4.5997 1.65873 3.79754C2.01825 3.09193 2.59193 2.51825 3.29754 2.15873C4.0997 1.75 5.1498 1.75 7.25 1.75H12.75C14.8502 1.75 15.9003 1.75 16.7025 2.15873C17.4081 2.51825 17.9817 3.09193 18.3413 3.79754C18.75 4.5997 18.75 5.6498 18.75 7.75V24.25L10 19.25L1.25 24.25V7.75Z"
+        stroke={isFavorite ? PRIMARY_PURPLE : BLACK}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  </button>
 );

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -22,6 +22,7 @@ import {
   StyledTextArea,
   TextDiv,
   ButtonGroup,
+  BookMarkIcon,
 } from './ProblemDetailPage.style';
 
 const { TabPane } = Tabs;
@@ -97,6 +98,7 @@ const ProblemDetailPage: React.FC = () => {
       {/* todo: 사이드바 사이즈 조절 가능허도록 수정 예정, 내 답변 기록 데이터 추가 예정 (API 필요), */}
       <ProblemDetailContainer>
         <ProblemInfoBar>
+          <BookMarkIcon isFavorite={problemDetail?.isFavorite ?? false} />
           <Title>{problemDetail && problemDetail.title}</Title>
           <Category>{problemDetail?.categoryList || 'None'}</Category>
           <ProblemInfo>난이도: {problemDetail?.level}</ProblemInfo>

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import BasicPageLayout from '@components/layout/BasicPageLayout';
-import { getProblemDetail, solveProblem } from '@services/api/problemService';
+import { getProblemDetail, solveProblem, toggleFavorite } from '@services/api/problemService';
 import { ProblemDetailInfo } from '@type/problem';
 import { Tabs, Modal } from 'antd';
 import { showAlertPopup } from '@utils/showPopup';
@@ -85,6 +85,22 @@ const ProblemDetailPage: React.FC = () => {
     navigate('/login');
   };
 
+  const handleClickFavorite = async () => {
+    if (!isAuthenticated) {
+      showAlertPopup('로그인이 필요한 기능입니다.');
+      return;
+    }
+    try {
+      if (!problemDetail) {
+        return;
+      }
+      await toggleFavorite(problemDetail.id, !problemDetail.isFavorite); // toggleFavorite 함수는 API 호출을 구현해야 합니다.
+      setProblemDetail({ ...problemDetail, isFavorite: !problemDetail.isFavorite });
+    } catch (err) {
+      showAlertPopup('즐겨찾기 업데이트에 실패했습니다.');
+    }
+  };
+
   if (loading) {
     return <div>Loading...</div>;
   }
@@ -98,7 +114,10 @@ const ProblemDetailPage: React.FC = () => {
       {/* todo: 사이드바 사이즈 조절 가능허도록 수정 예정, 내 답변 기록 데이터 추가 예정 (API 필요), */}
       <ProblemDetailContainer>
         <ProblemInfoBar>
-          <BookMarkIcon isFavorite={problemDetail?.isFavorite ?? false} />
+          <BookMarkIcon
+            isFavorite={problemDetail?.isFavorite ?? false}
+            onClick={handleClickFavorite}
+          />
           <Title>{problemDetail && problemDetail.title}</Title>
           <Category>{problemDetail?.categoryList || 'None'}</Category>
           <ProblemInfo>난이도: {problemDetail?.level}</ProblemInfo>

--- a/src/services/api/problemService.ts
+++ b/src/services/api/problemService.ts
@@ -39,3 +39,8 @@ export const solveProblem = async (
   const response = await apiClient.post(`/problem/${id}/solve`, { answer });
   return response.data;
 };
+
+export const toggleFavorite = async (id: number, isFavorite: boolean): Promise<ApiResponse> => {
+  const response = await apiClient.post(`/problem/${id}/favorite`, { isFavorite });
+  return response.data;
+};

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -20,6 +20,7 @@ const GlobalStyle = createGlobalStyle`
 
   button {
     border: none;
+    background-color: transparent;
   }
 `;
 

--- a/src/type/problem.d.ts
+++ b/src/type/problem.d.ts
@@ -13,4 +13,5 @@ export interface ProblemDetailInfo {
   grading: string;
   level: number;
   categoryList: Category[];
+  isFavorite: boolean;
 }


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-173](https://soma-til.atlassian.net/browse/TIL-173)

<br>

## 개요
기술 학습 문제 상세 화면에 즐겨찾기 기능 추가

<br>

## 내용
- 기술 학습 문제 상세 화면에 즐겨찾기 기능 추가
  - 문제 상세 정보 즐겨찾기 정보 추가
  - 즐겨찾기 동작하도록 등록/삭제 기능 추가
- 문제 상세 로딩/즐겨찾기 요청 실패시 toast 메시지 띄우기

https://github.com/user-attachments/assets/c28c73d8-22bb-4165-8e71-70d49579533c


<br>

## 리뷰어한테 할 말
- 테스트 하다보니 프론트 토큰 관리 쪽이 문제가 있는 것 같아서 버그 픽스를 해야할 것 같습니다.. 해결 전까지는 로그인 진행 후 테스트 부탁드립니다🥲


[TIL-173]: https://soma-til.atlassian.net/browse/TIL-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ