### PR TITLE
[TIL-177] access 토큰 정보가 있을 때만 Authorization 헤더 추가

### DIFF
--- a/src/services/api/axios.ts
+++ b/src/services/api/axios.ts
@@ -19,7 +19,9 @@ apiClient.interceptors.request.use(
   (config) => {
     const newConfig = { ...config };
     const accessToken = useAuthStore.getState().getAccessToken();
-    newConfig.headers.Authorization = accessToken ? formatBearerToken(accessToken) : ''; // 헤더에 토큰 추가
+    if (accessToken) {
+      newConfig.headers.Authorization = formatBearerToken(accessToken); // 헤더에 토큰 추가
+    }
 
     return newConfig;
   },


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-177](https://soma-til.atlassian.net/browse/TIL-177)

<br>

## 개요
access 토큰 정보가 있을 때만 Authorization 헤더 추가
- 문제 상황 : 로그인되지 않은 사용자의 경우에도 axios 인터셉터에서 Authorization 헤더에 빈 값을 넣어줘서 일부 Authorization 헤더 값 검증시 오류 발생
<br>

## 내용
- axios 인터셉터에서 access 토큰 정보가 있을 때만 Authorization 헤더 추가

<br>

## 리뷰어한테 할 말
🫨

[TIL-177]: https://soma-til.atlassian.net/browse/TIL-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ