### PR TITLE
[TIL-166] 히스토리 탭 화면 구현

### DIFF
--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
@@ -39,7 +39,7 @@ export const ProblemInfo = styled.div`
 export const ContentContainer = styled.div`
   display: flex;
   flex: 0.8;
-  overflow: auto;
+  overflow: hidden;
 `;
 
 export const QuestionSection = styled.div`

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -28,6 +28,7 @@ import {
   ButtonGroup,
   BookMarkIcon,
 } from './ProblemDetailPage.style';
+import ProblemHistory from './ProblemHistoryTab';
 
 const { TabPane } = Tabs;
 
@@ -42,7 +43,76 @@ const ProblemDetailPage: React.FC = () => {
   const [answer, setAnswer] = useState<string>('');
   const [result, setResult] = useState<string | null>(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isPassed, setIsPassed] = useState(false); // todo: API 연동 후 수정 필요
   const { isAuthenticated, checkAuthentication } = useAuthStore();
+
+  // Mock data for 내 답변 기록 -> API 연동 후, 삭제
+  const ProblemHistoryMockData = [
+    {
+      id: 1,
+      answer:
+        '배열은 메모리 상에 연속적으로 저장된 요소들의 집합으로, 인덱스를 통해 O(1) 시간 복잡도로 빠르게 접근할 수 있습니다.',
+      feedback: '연결리스트에 대한 추가적인 설명 필요함',
+      score: 'PASS',
+      created_date: '2024-08-09',
+    },
+    {
+      id: 2,
+      answer:
+        '배열은 메모리 상에 연속적으로 저장된 요소들의 집합으로, 인덱스를 통해 O(1) 시간 복잡도로 빠르게 접근할 수 있습니다.',
+      feedback: '연결리스트에 대한 추가적인 설명 필요함',
+      score: 'PASS',
+      created_date: '2024-08-09',
+    },
+    {
+      id: 2,
+      answer:
+        '배열은 메모리 상에 연속적으로 저장된 요소들의 집합으로, 인덱스를 통해 O(1) 시간 복잡도로 빠르게 접근할 수 있습니다.',
+      feedback: '연결리스트에 대한 추가적인 설명 필요함',
+      score: 'PASS',
+      created_date: '2024-08-09',
+    },
+    {
+      id: 2,
+      answer:
+        '배열은 메모리 상에 연속적으로 저장된 요소들의 집합으로, 인덱스를 통해 O(1) 시간 복잡도로 빠르게 접근할 수 있습니다.',
+      feedback: '연결리스트에 대한 추가적인 설명 필요함',
+      score: 'PASS',
+      created_date: '2024-08-09',
+    },
+    {
+      id: 2,
+      answer:
+        '배열은 메모리 상에 연속적으로 저장된 요소들의 집합으로, 인덱스를 통해 O(1) 시간 복잡도로 빠르게 접근할 수 있습니다.',
+      feedback: '연결리스트에 대한 추가적인 설명 필요함',
+      score: 'PASS',
+      created_date: '2024-08-09',
+    },
+    {
+      id: 2,
+      answer:
+        '배열은 메모리 상에 연속적으로 저장된 요소들의 집합으로, 인덱스를 통해 O(1) 시간 복잡도로 빠르게 접근할 수 있습니다.',
+      feedback: '연결리스트에 대한 추가적인 설명 필요함',
+      score: 'PASS',
+      created_date: '2024-08-09',
+    },
+    {
+      id: 2,
+      answer:
+        '배열은 메모리 상에 연속적으로 저장된 요소들의 집합으로, 인덱스를 통해 O(1) 시간 복잡도로 빠르게 접근할 수 있습니다.',
+      feedback: '연결리스트에 대한 추가적인 설명 필요함',
+      score: 'PASS',
+      created_date: '2024-08-09',
+    },
+    {
+      id: 2,
+      answer:
+        '배열은 메모리 상에 연속적으로 저장된 요소들의 집합으로, 인덱스를 통해 O(1) 시간 복잡도로 빠르게 접근할 수 있습니다.',
+      feedback: '연결리스트에 대한 추가적인 설명 필요함',
+      score: 'PASS',
+      created_date: '2024-08-09',
+    },
+  ];
 
   useEffect(() => {
     checkAuthentication();
@@ -61,6 +131,7 @@ const ProblemDetailPage: React.FC = () => {
           throw new Error('문제 정보를 가져오는 중 오류가 발생했습니다.');
         }
         setProblemDetail(response.result.problemInfo);
+        setIsPassed(true); // todo: API 연동 후 수정 필요
       } catch (err) {
         setError(getErrorMessage(err));
       } finally {
@@ -134,7 +205,7 @@ const ProblemDetailPage: React.FC = () => {
 
   return (
     <BasicPageLayout>
-      {/* todo: 사이드바 사이즈 조절 가능허도록 수정 예정, 내 답변 기록 데이터 추가 예정 (API 필요), */}
+      {/* todo: 사이드바 사이즈 조절 가능허도록 수정 예정, 내 답변 기록 데이터 API 연동 필요 */}
       <ProblemDetailContainer>
         <ProblemInfoBar>
           <BookMarkIcon
@@ -166,7 +237,11 @@ const ProblemDetailPage: React.FC = () => {
                 </TextDiv>
               </TabPane>
               <TabPane tab="내 답변 기록" key="2" disabled={!isAuthenticated}>
-                <div>내 답변 기록</div>
+                <ProblemHistory
+                  problemSolution={problemDetail?.solution || ''}
+                  historyData={ProblemHistoryMockData}
+                  isPassed={isPassed}
+                />
               </TabPane>
             </Tabs>
           </AnswerSection>

--- a/src/components/pages/ProblemDetailPage/ProblemHistoryTab.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemHistoryTab.style.tsx
@@ -1,0 +1,71 @@
+// ProblemHistoryTab.style.tsx
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  background-color: #f9f9f9;
+  overflow: hidden;
+`;
+
+export const SolutionBox = styled.div`
+  background-color: #ffffff;
+  padding: 16px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  flex: 0.3;
+  display: flex;
+  flex-direction: column;
+
+  p {
+    font-size: 16px;
+    line-height: 1.5;
+    overflow-y: auto;
+    flex: 1;
+    margin: 0;
+  }
+`;
+
+export const SubTitleBox = styled.div`
+  background-color: #555555;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  padding: 8px 16px;
+  border-radius: 10px;
+  display: inline-block;
+  width: fit-content;
+`;
+
+export const StyledTable = styled.div`
+  flex: 0.7;
+  .ant-table-wrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .ant-table {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .ant-table-thead > tr > th {
+    background-color: #f5f5f5;
+    font-weight: bold;
+  }
+
+  .ant-table-tbody > tr > td {
+    background-color: #ffffff;
+  }
+
+  .ant-table-tbody > tr:hover > td {
+    background-color: #f0f0f0;
+  }
+
+  .ant-pagination-item-active {
+    border-color: #40a9ff;
+  }
+`;

--- a/src/components/pages/ProblemDetailPage/ProblemHistoryTab.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemHistoryTab.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Table } from 'antd';
+import type { TableColumnsType } from 'antd';
+import { ProblemHistoryInfo } from '@type/problem';
+import { Container, SolutionBox, StyledTable, SubTitleBox } from './ProblemHistoryTab.style';
+
+interface ProblemHistoryProps {
+  isPassed: boolean;
+  problemSolution: string;
+  historyData: ProblemHistoryInfo[];
+}
+
+const columns: TableColumnsType<ProblemHistoryInfo> = [
+  {
+    title: '답변',
+    dataIndex: 'answer',
+    key: 'answer',
+    width: 300,
+  },
+  {
+    title: '피드백',
+    dataIndex: 'feedback',
+    key: 'feedback',
+    width: 300,
+  },
+  {
+    title: '제출 날짜',
+    dataIndex: 'created_date',
+    key: 'created_date',
+    width: 150,
+  },
+  {
+    title: '결과',
+    dataIndex: 'score',
+    key: 'score',
+    width: 100,
+  },
+];
+
+const ProblemHistory: React.FC<ProblemHistoryProps> = ({
+  problemSolution,
+  historyData,
+  isPassed,
+}) => {
+  const dataSource = historyData.map((item) => ({
+    key: item.id,
+    ...item,
+  }));
+
+  return (
+    <Container>
+      <SubTitleBox>모범 답안</SubTitleBox>
+      <SolutionBox>
+        {isPassed ? <p>{problemSolution}</p> : <p>문제를 PASS해야 솔루션을 볼 수 있습니다.</p>}
+      </SolutionBox>
+      <SubTitleBox>답변 기록</SubTitleBox>
+      <StyledTable>
+        <Table columns={columns} dataSource={dataSource} pagination={false} scroll={{ y: 400 }} />
+      </StyledTable>
+    </Container>
+  );
+};
+
+export default ProblemHistory;

--- a/src/type/problem.d.ts
+++ b/src/type/problem.d.ts
@@ -15,3 +15,11 @@ export interface ProblemDetailInfo {
   categoryList: Category[];
   isFavorite: boolean;
 }
+
+export interface ProblemHistoryInfo {
+  id: number;
+  answer: string;
+  feedback: string;
+  score: string;
+  created_date: string;
+}


### PR DESCRIPTION

## 이슈 번호(링크)

[TIL-166](https://soma-til.atlassian.net/browse/TIL-166)

<br>

## 개요

- 히스토리 탭 화면 구현

<br>

## 내용

- solution pass 여부 임시 변수로 처리 
- history 값 Mockdata로 처리

![image](https://github.com/user-attachments/assets/82f5e577-8d60-4888-9ea0-bf0075e49f51)


<br>

## 리뷰어한테 할 말

👀 


[TIL-166]: https://soma-til.atlassian.net/browse/TIL-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ