### PR TITLE
[TIL-194] 카테고리 store 생성 및 기술학습 문제 리스트/상세 카테고리 정보 출력

### DIFF
--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -10,6 +10,7 @@ import { ProblemDetailInfo } from '@type/problem';
 import { showAlertPopup } from '@utils/showPopup';
 import { getErrorMessage } from '@utils/errorHandler';
 import useAuthStore from '@store/useAuthStore';
+import useCategoryStore from '@store/useCategoryStore';
 import {
   ProblemDetailContainer,
   ProblemInfoBar,
@@ -45,6 +46,7 @@ const ProblemDetailPage: React.FC = () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isPassed, setIsPassed] = useState(false); // todo: API 연동 후 수정 필요
   const { isAuthenticated, checkAuthentication } = useAuthStore();
+  const { getCategoryList, transformCategoryTagList } = useCategoryStore();
 
   // Mock data for 내 답변 기록 -> API 연동 후, 삭제
   const ProblemHistoryMockData = [
@@ -126,6 +128,7 @@ const ProblemDetailPage: React.FC = () => {
 
     const fetchProblemDetail = async () => {
       try {
+        await getCategoryList();
         const response = await getProblemDetail(id);
         if (!response.result || !response.result.problemInfo) {
           throw new Error('문제 정보를 가져오는 중 오류가 발생했습니다.');
@@ -140,7 +143,7 @@ const ProblemDetailPage: React.FC = () => {
     };
 
     fetchProblemDetail();
-  }, [id]);
+  }, [getCategoryList, id]);
 
   useEffect(() => {
     if (error) {
@@ -213,7 +216,9 @@ const ProblemDetailPage: React.FC = () => {
             onClick={handleClickFavorite}
           />
           <Title>{problemDetail && problemDetail.title}</Title>
-          <Category>{problemDetail?.categoryList || 'None'}</Category>
+          <Category>
+            {problemDetail && transformCategoryTagList(problemDetail.categoryList).join(',')}
+          </Category>
           <ProblemInfo>난이도: {problemDetail?.level}</ProblemInfo>
           <ProblemInfo>완료한 사람: 0명</ProblemInfo>
           <ProblemInfo>정답률: 0%</ProblemInfo>

--- a/src/components/pages/ProblemListPage/ProblemListPage.tsx
+++ b/src/components/pages/ProblemListPage/ProblemListPage.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
 import BasicPageLayout from '@components/layout/BasicPageLayout';
+import useCategoryStore from '@store/useCategoryStore';
 import { getProblemList } from '@services/api/problemService';
 import { ProblemOverviewInfo } from '@type/problem';
 import { Pagination, Table } from 'antd';
 import { ColumnsType } from 'antd/es/table';
-
 import { ProblemPageContainer, SubTitle } from './ProblemListPage.style';
 import SearchBar from './SearchBar';
 
@@ -25,7 +24,10 @@ const columns: ColumnsType<ProblemOverviewInfo> = [
     title: '카테고리',
     dataIndex: 'categoryList',
     key: 'categoryList',
-    render: () => <span>None</span>,
+    render: (categoryIds) => {
+      const { transformCategoryTagList } = useCategoryStore.getState();
+      return <span>{transformCategoryTagList(categoryIds).join(',')}</span>;
+    },
   },
   {
     title: '난이도',
@@ -52,10 +54,12 @@ const ProblemListPage: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
+  const { getCategoryList } = useCategoryStore();
 
   useEffect(() => {
     const fetchProblemList = async () => {
       try {
+        await getCategoryList();
         const response = await getProblemList();
         setProblemList(response.result?.problemList || []);
       } catch (err) {
@@ -66,20 +70,21 @@ const ProblemListPage: React.FC = () => {
     };
 
     fetchProblemList();
-  }, []);
+  }, [getCategoryList]);
 
   const onRowClick = (record: ProblemOverviewInfo) => {
     navigate(`/problem/${record.id}`);
   };
+
   if (loading) {
     return <div>Loading...</div>;
   }
   if (error) {
     return <div>{error}</div>;
   }
+
   return (
     <BasicPageLayout>
-      {/* todo: 검색, 페이징 기능 추가 예정 */}
       <ProblemPageContainer>
         <SubTitle>기술학습</SubTitle>
         <SearchBar />

--- a/src/store/useCategoryStore.ts
+++ b/src/store/useCategoryStore.ts
@@ -1,0 +1,35 @@
+import { getCategoryList } from '@services/api/categoryService';
+import storeSupport from '@store/support';
+import { Category } from '@type/category';
+
+interface CategoryInfo {
+  categoryList: Category[];
+  setCategoryList: (categoryList: Category[]) => void;
+  getCategoryList: () => Promise<Category[]>;
+  transformCategoryTagList: (categoryIds: number[]) => string[];
+}
+
+const useCategoryStore = storeSupport<CategoryInfo>(
+  (set, get) => ({
+    categoryList: [],
+    setCategoryList: (categoryList) => set({ categoryList }),
+    getCategoryList: async () => {
+      if (get().categoryList.length === 0) {
+        const response = await getCategoryList();
+        const categories = response.result?.categoryList || [];
+        set({ categoryList: categories });
+      }
+      return get().categoryList;
+    },
+    transformCategoryTagList: (categoryIds: number[]) => {
+      const categoryNames = categoryIds.map((id: number) => {
+        const category = get().categoryList.find((c) => c.id === id);
+        return category ? category.tag : 'Unknown';
+      });
+      return categoryNames;
+    },
+  }),
+  'CATEGORY_STORE',
+);
+
+export default useCategoryStore;


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-194](https://soma-til.atlassian.net/browse/TIL-194)

<br>

## 개요
카테고리 store 생성 및 기술학습 문제 리스트/상세 카테고리 정보 출력

<br>

## 내용
- 카테고리 store 생성 → `useCategoryStore`
  - `getCategoryList` : 카테고리 정보가 없으면 데이터 가져옴
  - `transformCategoryTagList` : 카테고리 id 리스트에 해당하는 태그명 리스트 반환
- 기술학습 문제 리스트/상세 카테고리 정보 출력

https://github.com/user-attachments/assets/7becd0bb-a6dd-4699-9609-8650205a6bf7



<br>

## 리뷰어한테 할 말
🏓


[TIL-194]: https://soma-til.atlassian.net/browse/TIL-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ