### PR TITLE
[TIL-200] 카테고리 store categoryList undefined일 때 처리 로직 추가

### DIFF
--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -147,7 +147,9 @@ const ProblemDetailPage: React.FC = () => {
           />
           <Title>{problemDetail && problemDetail.title}</Title>
           <Category>
-            {problemDetail && transformCategoryTagList(problemDetail.categoryList).join(',')}
+            {Array.isArray(problemDetail.categoryList)
+              ? transformCategoryTagList(problemDetail.categoryList).join(',')
+              : 'None'}
           </Category>
           <ProblemInfo>난이도: {problemDetail?.level}</ProblemInfo>
           <ProblemInfo>완료한 사람: 0명</ProblemInfo>

--- a/src/store/useCategoryStore.ts
+++ b/src/store/useCategoryStore.ts
@@ -22,6 +22,8 @@ const useCategoryStore = storeSupport<CategoryInfo>(
       return get().categoryList;
     },
     transformCategoryTagList: (categoryIds: number[]) => {
+      if (get().categoryList.length === 0) return [];
+
       const categoryNames = categoryIds.map((id: number) => {
         const category = get().categoryList.find((c) => c.id === id);
         return category ? category.tag : 'Unknown';


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-200](https://soma-til.atlassian.net/browse/TIL-200)

<br>

## 개요
카테고리 store categoryList undefined일 때 처리 로직 추가
```shell
.Cannot read properties of undefined (reading 'map') TypeError: Cannot read properties of undefined (reading 'map') at transformCategoryTagList (http://localhost:3000/static/js/bundle.js:8076:39) at ProblemDetailPage (http://localhost:3000/static/js/bundle.js:5890:38) at renderWithHooks (http://localhost:3000/static/js/bundle.js:102624:22) at mountIndeterminateComponent (http://localhost:3000/static/js/bundle.js:106595:17) at beginWork (http://localhost:3000/static/js/bundle.js:107898:20) at HTMLUnknownElement.callCallback (http://localhost:3000/static/js/bundle.js:92880:18) at Object.invokeGuardedCallbackDev (http://localhost:3000/static/js/bundle.js:92924:20) at invokeGuardedCallback (http://localhost:3000/static/js/bundle.js:92981:35) at beginWork$1 (http://localhost:3000/static/js/bundle.js:112879:11) at performUnitOfWork (http://localhost:3000/static/js/bundle.js:112127:16)
```
- 문제 상황 : transformCategoryTagList 함수가 undefined인 값을 받았을 때 오류 발생

<br>

## 내용
- 카테고리 store categoryList undefined일 때 처리 로직 추가

<br>

## 리뷰어한테 할 말
👣


[TIL-200]: https://soma-til.atlassian.net/browse/TIL-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ