### PR TITLE
[TIL-205] 기술학습 문제 답변 제출 후 API 응답 처리

### DIFF
--- a/src/constants/grading.ts
+++ b/src/constants/grading.ts
@@ -1,0 +1,10 @@
+export const GRADING_STATUS = {
+  PENDING: 'PENDING',
+  COMPLETED: 'COMPLETED',
+  ERROR: 'ERROR',
+};
+
+export const GRADING_RESULT = {
+  PASS: 'PASS',
+  FAIL: 'FAIL',
+};

--- a/src/services/api/problemService.ts
+++ b/src/services/api/problemService.ts
@@ -1,5 +1,6 @@
 import apiClient from '@services/api/axios';
 import { ApiResponse } from '@type/api';
+import { GradingResult } from '@type/grading';
 import { ProblemDetailInfo, ProblemOverviewInfo, ProblemSubmitHistoryInfo } from '@type/problem';
 import qs from 'qs';
 
@@ -17,10 +18,17 @@ export interface ProblemDetailData {
   problemInfo: ProblemDetailInfo;
 }
 
-export interface SolveProblemData {
-  problemResult: {
-    status: string;
-  };
+export interface SubmitInfo {
+  submitId: number;
+  status: string;
+}
+
+export interface SubmitProblemData {
+  submitInfo: SubmitInfo;
+}
+
+export interface SubmitGradingResult {
+  gradingResult: GradingResult;
 }
 
 export interface ProblemListParams {
@@ -49,10 +57,10 @@ export const getProblemDetail = async (id: string): Promise<ApiResponse<ProblemD
   return response.data;
 };
 
-export const solveProblem = async (
+export const submitProblem = async (
   id: string,
   answer: string,
-): Promise<ApiResponse<SolveProblemData>> => {
+): Promise<ApiResponse<SubmitProblemData>> => {
   const response = await apiClient.post(`/problem/${id}/solve`, { answer });
   return response.data;
 };
@@ -66,5 +74,13 @@ export const getProblemSubmitHistory = async (
   id: string,
 ): Promise<ApiResponse<ProblemSubmitHistoryInfo>> => {
   const response = await apiClient.get(`/problem/${id}/history`);
+  return response.data;
+};
+
+export const getSubmitResult = async (
+  id: string,
+  submitId: number,
+): Promise<ApiResponse<SubmitGradingResult>> => {
+  const response = await apiClient.get(`/problem/${id}/result?submitId=${submitId}`);
   return response.data;
 };

--- a/src/type/grading.d.ts
+++ b/src/type/grading.d.ts
@@ -1,0 +1,10 @@
+import { GRADING_STATUS, GRADING_RESULT } from '@constants/grading';
+
+export type GradingStatus = (typeof GRADING_STATUS)[keyof typeof GRADING_STATUS];
+export type GradingResultType = (typeof GRADING_RESULT)[keyof typeof GRADING_RESULT];
+
+export interface GradingResult {
+  status: GradingStatus;
+  result: GradingResultType;
+  comment: string;
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-205](https://soma-til.atlassian.net/browse/TIL-205)

<br>

## 개요
기술학습 문제 답변 제출 후 API 응답 처리

<br>

## 내용
- 문제 답변 제출 후 submitId 데이터를 받아서
- 답변 결과 확인 API에 채점 정보 요청


https://github.com/user-attachments/assets/0760545a-e4fa-4e07-9341-e953ada9ecc6


<br>

## 리뷰어한테 할 말
- 기술학습 문제 답변 제출 후 API 응답 처리에만 초점이 맞춰진 task입니다!
- 작업하면서 발견한 리팩토링할 부분들은 아래와 같습니다😅
  - 제출 이력 탭 클릭시 API를 매번 호출해야 하는데 한번만 호출하고 다시 새로 API를 받아오지 않는 부분 있음
  - 피드백 보러가기 버튼 동작 안함


[TIL-205]: https://soma-til.atlassian.net/browse/TIL-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ