### PR TITLE
[TIL-210] 문제 리스트 전체 스타일링

### DIFF
--- a/src/components/pages/ProblemListPage/ProblemListPage.style.tsx
+++ b/src/components/pages/ProblemListPage/ProblemListPage.style.tsx
@@ -1,15 +1,131 @@
 import styled from 'styled-components';
 
-export const ProblemPageContainer = styled.div`
-  display: inline-block;
+export const ProblemListContainer = styled.div`
   width: 100%;
-  padding: 20px 200px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  display: flex;
+  flex-direction: column;
 `;
 
-export const SubTitle = styled.h3`
-  padding: 5px;
+export const SearchBarContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 200px;
 `;
 
-export const Table = styled.div`
-  padding: 20px;
+export const SubTitle = styled.h2`
+  width: 100%;
+  margin-top: 50px;
+  margin-bottom: 20px;
+`;
+
+export const TableContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 200px;
+  background-color: #f9fafc;
+  flex-grow: 1;
+`;
+
+export const TableOptionContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 30px;
+`;
+
+export const OptionGroup = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+export const TotalItems = styled.div`
+  color: #4b4c4c;
+  padding: 5px 10px;
+`;
+
+export const FavoriteButton = styled.button`
+  border-radius: 5px;
+  border: 1px solid #bbb;
+  padding: 5px 10px;
+  font-size: 15px;
+  cursor: pointer;
+`;
+
+export const OrderOptionDropDown = styled.select`
+  border-radius: 5px;
+  border: 1px solid #bbb;
+  padding: 5px 10px;
+  font-size: 15px;
+  cursor: pointer;
+`;
+
+export const CustomTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+  font-size: 16px;
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+export const TableHeader = styled.thead`
+  background-color: #ededff;
+`;
+
+export const TableHeaderCell = styled.th`
+  padding: 12px 15px;
+  font-weight: bold;
+  text-align: left;
+  height: 60px;
+`;
+
+export const TableRow = styled.tr`
+  border-bottom: 1px solid #dee2e6;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  height: 60px;
+
+  &:hover {
+    background-color: #e9ecef;
+  }
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+export const TableCell = styled.td`
+  padding: 12px 15px;
+  height: 60px;
+`;
+
+export const StatusText = styled.span`
+  color: #5c7cfa;
+  font-weight: bold;
+`;
+
+export const LevelText = styled.span`
+  color: #4e63ed;
+  font-weight: bold;
+`;
+
+export const TitleWithTags = styled.div`
+  display: flex;
+  align-items: center;
+
+  & > span:first-child {
+    margin-right: 10px; /* 제목과 태그 사이 간격 */
+  }
+`;
+
+export const CategoryTag = styled.span`
+  display: inline-block;
+  background-color: #e0f7fa; /* 태그 배경색 */
+  color: #00796b; /* 태그 텍스트 색상 */
+  padding: 5px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  margin-right: 8px;
 `;

--- a/src/components/pages/ProblemListPage/ProblemListPage.tsx
+++ b/src/components/pages/ProblemListPage/ProblemListPage.tsx
@@ -6,68 +6,42 @@ import useLoadingStore from '@store/useLoadingStore';
 import useCategoryStore from '@store/useCategoryStore';
 import { getProblemList, ProblemListParams } from '@services/api/problemService';
 import { ProblemOverviewInfo } from '@type/problem';
-import { Table } from 'antd';
-import { ColumnsType, TablePaginationConfig } from 'antd/es/table';
-import { ProblemPageContainer, SubTitle } from './ProblemListPage.style';
+import {
+  ProblemListContainer,
+  SubTitle,
+  CustomTable,
+  TableHeader,
+  TableRow,
+  TableCell,
+  TableHeaderCell,
+  StatusText,
+  SearchBarContainer,
+  TableContentContainer,
+  TableOptionContainer,
+  TotalItems,
+  FavoriteButton,
+  OrderOptionDropDown,
+  OptionGroup,
+  LevelText,
+} from './ProblemListPage.style';
 import SearchBar from './SearchBar';
-
-// to-do. 페이징 & 검색 상태 저장
-const columns: ColumnsType<ProblemOverviewInfo> = [
-  {
-    title: '상태',
-    key: 'status',
-    render: () => <span>Pass</span>,
-  },
-  {
-    title: '제목',
-    dataIndex: 'title',
-    key: 'title',
-  },
-  {
-    title: '카테고리',
-    dataIndex: 'categoryList',
-    key: 'categoryList',
-    render: (categoryIds) => {
-      const { transformCategoryTagList } = useCategoryStore.getState();
-      return <span>{transformCategoryTagList(categoryIds).join(',')}</span>;
-    },
-  },
-  {
-    title: '난이도',
-    dataIndex: 'level',
-    key: 'level',
-    render: (level) => <span>Lv.{level}</span>,
-  },
-  {
-    title: '완료한 사람',
-    dataIndex: 'solved',
-    key: 'solved',
-    render: (solved) => <span>{solved}명</span>,
-  },
-  {
-    title: '정답률',
-    dataIndex: 'percentage',
-    key: 'percentage',
-    render: (percentage) => <span>{percentage}%</span>,
-  },
-];
 
 const ProblemListPage: React.FC = () => {
   const [problemList, setProblemList] = useState<ProblemOverviewInfo[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState<number>(0);
-  const [pageSize, setPageSize] = useState<number>(10);
+  // const [pageSize, setPageSize] = useState<number>(10);
   const [totalItems, setTotalItems] = useState<number>(0);
   const [levelList, setLevelList] = useState<number[]>([]);
   const navigate = useNavigate();
-  const { getCategoryList, categoryList } = useCategoryStore();
+  const { getCategoryList, categoryList, transformCategoryTagList } = useCategoryStore();
   const { getIsLoading, setIsLoading } = useLoadingStore();
 
   const fetchProblemList = async (params: ProblemListParams = {}) => {
     try {
       setIsLoading(true);
       await getCategoryList();
-      const response = await getProblemList({ ...params, page: currentPage, size: pageSize });
+      const response = await getProblemList({ ...params, page: currentPage });
       setProblemList(response.result?.problemList || []);
       setTotalItems(response.result?.pageInfo.totalItems || 0);
       const uniqueLevels = Array.from(
@@ -84,7 +58,7 @@ const ProblemListPage: React.FC = () => {
   useEffect(() => {
     fetchProblemList();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getCategoryList, setIsLoading, currentPage, pageSize]);
+  }, [getCategoryList, setIsLoading, currentPage]);
 
   const handleSearch = (
     keyword: string,
@@ -100,10 +74,10 @@ const ProblemListPage: React.FC = () => {
     fetchProblemList(params);
   };
 
-  const handlePageChange = (pagination: TablePaginationConfig) => {
-    setCurrentPage(pagination.current || 1);
-    setPageSize(pagination.pageSize || 10);
-  };
+  // const handlePageChange = (pagination: TablePaginationConfig) => {
+  //   setCurrentPage(pagination.current || 1);
+  //   setPageSize(pagination.pageSize || 10);
+  // };
 
   const onRowClick = (record: ProblemOverviewInfo) => {
     navigate(`/problem/${record.id}`);
@@ -118,30 +92,63 @@ const ProblemListPage: React.FC = () => {
 
   return (
     <BasicPageLayout>
-      <ProblemPageContainer>
-        <SubTitle>기술학습</SubTitle>
-        <SearchBar onSearch={handleSearch} levelList={levelList} categoryList={categoryList} />
-        {problemList.length === 0 ? (
-          <div>문제가 없습니다.</div>
-        ) : (
-          <Table
-            columns={columns}
-            dataSource={problemList}
-            rowKey="id"
-            pagination={{
-              align: 'center',
-              current: currentPage,
-              pageSize,
-              total: totalItems,
-              showSizeChanger: true,
-            }}
-            onChange={(page) => handlePageChange(page)}
-            onRow={(record) => ({
-              onClick: () => onRowClick(record),
-            })}
-          />
-        )}
-      </ProblemPageContainer>
+      <ProblemListContainer>
+        <SearchBarContainer>
+          <SubTitle>기술 학습</SubTitle>
+          <SearchBar onSearch={handleSearch} levelList={levelList} categoryList={categoryList} />
+        </SearchBarContainer>
+        <TableContentContainer>
+          <TableOptionContainer>
+            <OptionGroup>
+              <TotalItems>{totalItems} 문제</TotalItems>
+              <FavoriteButton>즐겨찾기</FavoriteButton>
+            </OptionGroup>
+            <OptionGroup>
+              <OrderOptionDropDown> </OrderOptionDropDown>
+            </OptionGroup>
+          </TableOptionContainer>
+          {problemList.length === 0 ? (
+            <div>문제가 없습니다.</div>
+          ) : (
+            <>
+              <CustomTable>
+                <TableHeader>
+                  <TableHeaderCell>상태</TableHeaderCell>
+                  <TableHeaderCell>제목</TableHeaderCell>
+                  <TableHeaderCell>카테고리</TableHeaderCell>
+                  <TableHeaderCell>난이도</TableHeaderCell>
+                  <TableHeaderCell>완료한 사람</TableHeaderCell>
+                  <TableHeaderCell>정답률</TableHeaderCell>
+                </TableHeader>
+                <tbody>
+                  {problemList.map((problem) => (
+                    <TableRow key={problem.id} onClick={() => onRowClick(problem)}>
+                      <TableCell>
+                        <StatusText>Pass</StatusText>
+                      </TableCell>
+                      <TableCell>{problem.title}</TableCell>
+                      <TableCell>
+                        {transformCategoryTagList(problem.categoryList).join(', ')}
+                      </TableCell>
+                      <TableCell>
+                        <LevelText>{`Lv.${problem.level}`}</LevelText>
+                      </TableCell>
+                      <TableCell>0명</TableCell>
+                      <TableCell>0%</TableCell>
+                    </TableRow>
+                  ))}
+                </tbody>
+              </CustomTable>
+              {/* //todo: pagination 추가 예정 */}
+              {/* <PaginationContainer> */}
+              {/* <button>이전</button>
+              <span>1</span>
+              <button>다음</button> */}
+              {/* </PaginationContainer> */}
+            </>
+          )}
+        </TableContentContainer>
+      </ProblemListContainer>
     </BasicPageLayout>
   );
 };


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-210](https://soma-til.atlassian.net/browse/TIL-210)

<br>

## 개요

문제 리스트 전체 스타일링

<br>

## 내용
- 화면 전체 스타일링 작업
<img width="1692" alt="image" src="https://github.com/user-attachments/assets/a2923575-8e2d-4fa0-a8b2-c272de200dd8">


<br>

## 리뷰어한테 할 말

- 카테고리 태그 제목 옆에 붙이기 계속하다가 도저히 안되서 접었습니다..🥲 (시간 되면 나중에 다시 해보겠습니다)
- 추가 예정 작업
  - 페이징, 정렬, 사용자 상태, 즐겨찾기
  - 카테고리 태그 스타일링
  - 상태에 따른 글씨 색 변동, 레벨에 따른 글씨 색 변동
  - (푼 사람, 정답률)


[TIL-210]: https://soma-til.atlassian.net/browse/TIL-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ