### PR TITLE
[TIL-211] 기술 학습 상세 화면 스타일링

### DIFF
--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
@@ -1,27 +1,27 @@
 import styled from 'styled-components';
-import { Input } from 'antd';
-
-import { DISPLAY_HEIGHT_WITHOUT_HEADER } from '@styles/length';
 import { Button } from '@styles/ButtonStyle';
 import { BLACK, PRIMARY_PURPLE } from '@styles/pallete';
 
-const { TextArea } = Input;
-
 export const ProblemDetailContainer = styled.div`
+  width: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  height: 100vh;
-  position: relative;
-  min-height: ${DISPLAY_HEIGHT_WITHOUT_HEADER};
+  background-color: #f9fafc;
 `;
 
 export const ProblemInfoBar = styled.div`
   display: flex;
-  flex: 0.1;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
+  padding: 50px 300px;
+`;
+
+export const InfoGroup = styled.div`
+  display: flex;
+  gap: 20px;
 `;
 
 export const Title = styled.h1`
@@ -29,42 +29,118 @@ export const Title = styled.h1`
 `;
 
 export const Category = styled.div`
-  // 스타일링 추가
+  align-self: center;
 `;
 
 export const ProblemInfo = styled.div`
-  // 스타일링 추가
+  margin-left: 50px;
+  align-self: center;
+`;
+
+export const LevelText = styled.span`
+  color: #4e63ed;
+  font-size: 20px;
+  font-weight: bold;
+  margin-left: 15px;
 `;
 
 export const ContentContainer = styled.div`
   display: flex;
-  flex: 0.8;
+  gap: 20px;
+  height: 100%;
   overflow: hidden;
+  padding: 0px 300px 100px 300px;
 `;
 
 export const QuestionSection = styled.div`
-  width: 40%;
-  background: #f0f0f0;
+  width: 35%;
+  background: #fff;
   padding: 20px;
   overflow-y: auto;
+  border: 1px solid #e0e0e0;
+  border-radius: 20px;
+  box-shadow: 0px 1px 1px rgba(9, 9, 9, 0.15);
 `;
 
-export const AnswerSection = styled.div`
-  width: 60%;
-  overflow-y: auto;
+export const QuestionTitle = styled.div`
+  font-size: 18px;
+  font-weight: bold;
+  padding: 5px 0px 10px 10px;
+  border-bottom: 1px solid #e0e0e0;
 `;
 
 export const Question = styled.div`
-  padding: 5px;
+  padding: 20px 10px 10px 10px;
+`;
+
+export const AnswerSection = styled.div`
+  width: 65%;
+  background: #fff;
+  padding: 20px;
+  overflow-y: auto;
+  border: 1px solid #e0e0e0;
+  border-radius: 20px;
+  box-shadow: 0px 1px 1px rgba(9, 9, 9, 0.15);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+export const TabMenu = styled.div`
+  display: flex;
+  border-bottom: 1px solid #e0e0e0;
+`;
+
+export const TabMenuItem = styled.div.attrs<{ active: boolean; disabled?: boolean }>((props) => ({
+  active: props.active,
+  disabled: props.disabled,
+}))`
+  padding: 7px 22px;
+  cursor: pointer;
+  font-size: 18px;
+  font-weight: ${({ active }) => (active ? 'bold' : 'normal')};
+  color: ${({ active }) => (active ? PRIMARY_PURPLE : '#555555')};
+  border-bottom: ${({ active }) => (active ? `2px solid ${PRIMARY_PURPLE}` : 'none')};
+
+  &:hover {
+    color: ${PRIMARY_PURPLE};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    color: #c0c0c0;
+  }
+`;
+
+export const TextDiv = styled.textarea`
+  width: 100%;
+  height: 100px;
+  margin-top: 10px;
+  padding: 10px;
+  font-size: 15px;
+  line-height: 1.5;
+  resize: none;
+  border: none;
+  border-radius: 10px;
+  flex-grow: 1;
+  height: auto;
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px rgba(116, 52, 255, 0.5);
+  }
 `;
 
 export const BottomBar = styled.div`
   display: flex;
-  flex: 0.1;
   justify-content: space-between;
+  padding: 10px 300px;
   position: absolute;
   bottom: 0;
   width: 100%;
+  height: 60px;
+  background-color: #ffffff;
+  box-shadow: 0px -1px 10px rgba(0, 0, 0, 0.1);
 `;
 
 export const ButtonGroup = styled.div`
@@ -78,19 +154,59 @@ export const CustomButton = styled(Button)`
   font-size: 14px;
 `;
 
-export const CustomLoginButton = styled(Button)`
-  width: 150px;
-  height: 50px;
-  font-size: 14px;
-  margin-left: auto;
-`;
+export const ProblemSolveFooterButton = styled.button<{ type: string }>`
+  display: flex;
+  gap: 8px;  
+  align-items: center;
+  cursor: pointer;
+  width: max-content;
+  padding: 0 15px;
+  height: 40px;
+  border-radius: 7px;
 
-export const TextDiv = styled.div`
-  padding: 10px;
-`;
+  border: ${({ type }) => {
+    switch (type) {
+      case 'RED':
+      case 'PURPLE':
+        return 'none';
+      default:
+        return '1.5px solid #999';
+    }
+  }};
 
-export const StyledTextArea = styled(TextArea)`
-  resize: none;
+  color: ${({ type }) => {
+    switch (type) {
+      case 'RED':
+      case 'PURPLE':
+        return '#fff';
+      default:
+        return '#333';
+    }
+  }};
+
+  background-color: ${({ type }) => {
+    switch (type) {
+      case 'RED':
+        return '#f16060';
+      case 'PURPLE':
+        return '#7434FF';
+      default:
+        return '#fff';
+    }
+  }};
+
+  &:hover {
+    background-color:
+    ${({ type }) => {
+      switch (type) {
+        case 'RED':
+          return '#c73232';
+        case 'PURPLE':
+          return '#5929C1';
+        default:
+          return '#eee';
+      }
+    }}
 `;
 
 export const BookMarkIcon = ({

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 
-import { Tabs, Modal } from 'antd';
+import { Modal } from 'antd';
 import Loading from '@components/common/loading/Loading';
 import { useToast } from '@components/common/notification/ToastProvider';
 import BasicPageLayout from '@components/layout/BasicPageLayout';
@@ -22,6 +22,12 @@ import useAuthStore from '@store/useAuthStore';
 import useLoadingStore from '@store/useLoadingStore';
 import useCategoryStore from '@store/useCategoryStore';
 import {
+  QuestionCircleOutlined,
+  MessageOutlined,
+  RedoOutlined,
+  FileDoneOutlined,
+} from '@ant-design/icons';
+import {
   ProblemDetailContainer,
   ProblemInfoBar,
   ProblemInfo,
@@ -33,15 +39,17 @@ import {
   QuestionSection,
   AnswerSection,
   CustomButton,
-  CustomLoginButton,
-  StyledTextArea,
   TextDiv,
   ButtonGroup,
   BookMarkIcon,
+  InfoGroup,
+  QuestionTitle,
+  TabMenuItem,
+  TabMenu,
+  LevelText,
+  ProblemSolveFooterButton,
 } from './ProblemDetailPage.style';
 import ProblemHistory from './ProblemHistoryTab';
-
-const { TabPane } = Tabs;
 
 const ProblemDetailPage: React.FC = () => {
   const { notify } = useToast();
@@ -53,6 +61,7 @@ const ProblemDetailPage: React.FC = () => {
   const [answer, setAnswer] = useState<string>('');
   const [result, setResult] = useState<string | null>(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [activeTab, setActiveTab] = useState('answer');
   const { isAuthenticated, checkAuthentication } = useAuthStore();
   const { getIsLoading, setIsLoading } = useLoadingStore();
   const { getCategoryList, transformCategoryTagList } = useCategoryStore();
@@ -162,63 +171,61 @@ const ProblemDetailPage: React.FC = () => {
 
   return (
     <BasicPageLayout>
-      {/* todo: 사이드바 사이즈 조절 가능허도록 수정 예정, 내 답변 기록 데이터 API 연동 필요 */}
       <ProblemDetailContainer>
         <ProblemInfoBar>
-          <BookMarkIcon
-            isFavorite={problemDetail?.isFavorite ?? false}
-            onClick={handleClickFavorite}
-          />
-          <Title>{problemDetail && problemDetail.title}</Title>
-          <Category>
-            {Array.isArray(problemDetail.categoryList)
-              ? transformCategoryTagList(problemDetail.categoryList).join(',')
-              : 'None'}
-          </Category>
-          <ProblemInfo>난이도: {problemDetail?.level}</ProblemInfo>
-          <ProblemInfo>완료한 사람: 0명</ProblemInfo>
-          <ProblemInfo>정답률: 0%</ProblemInfo>
+          <InfoGroup>
+            <BookMarkIcon
+              isFavorite={problemDetail?.isFavorite ?? false}
+              onClick={handleClickFavorite}
+            />
+            <Title>{problemDetail && problemDetail.title}</Title>
+            <Category>
+              {Array.isArray(problemDetail.categoryList)
+                ? transformCategoryTagList(problemDetail.categoryList).join(',')
+                : 'None'}
+            </Category>
+          </InfoGroup>
+          <InfoGroup>
+            <ProblemInfo>
+              난이도
+              <LevelText>Lv.{problemDetail?.level}</LevelText>
+            </ProblemInfo>
+            <ProblemInfo>완료한 사람 0명</ProblemInfo>
+            <ProblemInfo>정답률 0%</ProblemInfo>
+          </InfoGroup>
         </ProblemInfoBar>
         <ContentContainer>
           <QuestionSection>
-            <h3>문제 설명</h3>
+            <QuestionTitle>문제 설명</QuestionTitle>
             <Question>{problemDetail?.question}</Question>
           </QuestionSection>
           <AnswerSection>
-            <Tabs defaultActiveKey="1" type="card">
-              <TabPane tab="답변" key="1">
-                <TextDiv>
-                  <StyledTextArea
-                    value={answer}
-                    onChange={(e) => setAnswer(e.target.value)}
-                    rows={25}
-                    placeholder="답변을 입력하세요."
-                    disabled={!isAuthenticated}
-                  />
-                </TextDiv>
-              </TabPane>
-              <TabPane tab="내 답변 기록" key="2" disabled={!isAuthenticated}>
-                {id && <ProblemHistory problemId={id} />}
-              </TabPane>
-            </Tabs>
+            <TabMenu>
+              <TabMenuItem active={activeTab === 'answer'} onClick={() => setActiveTab('answer')}>
+                답변
+              </TabMenuItem>
+              {isAuthenticated && (
+                <TabMenuItem
+                  active={activeTab === 'history'}
+                  onClick={() => setActiveTab('history')}
+                >
+                  내 답변 기록
+                </TabMenuItem>
+              )}
+            </TabMenu>
+            {activeTab === 'answer' && (
+              <TextDiv
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                placeholder={
+                  isAuthenticated ? '답변을 입력하세요.' : '로그인 후, 답변을 입력하세요.'
+                }
+                disabled={!isAuthenticated}
+              />
+            )}
+            {activeTab === 'history' && id && <ProblemHistory problemId={id} />}
           </AnswerSection>
         </ContentContainer>
-        <BottomBar>
-          {!isAuthenticated ? (
-            <CustomLoginButton onClick={handleLoginRedirect}>로그인하기</CustomLoginButton>
-          ) : (
-            <>
-              <ButtonGroup>
-                <CustomButton>질문하기</CustomButton>
-                <CustomButton>다른 사람의 답변</CustomButton>
-              </ButtonGroup>
-              <ButtonGroup>
-                <CustomButton onClick={handleReset}>답변 초기화</CustomButton>
-                <CustomButton onClick={handleSubmit}>제출</CustomButton>
-              </ButtonGroup>
-            </>
-          )}
-        </BottomBar>
         <Modal
           title="채점 결과"
           open={isModalVisible}
@@ -232,6 +239,36 @@ const ProblemDetailPage: React.FC = () => {
           <p>{result}</p>
         </Modal>
       </ProblemDetailContainer>
+      <BottomBar>
+        {!isAuthenticated ? (
+          <ProblemSolveFooterButton type="PURPLE" onClick={handleLoginRedirect}>
+            로그인하기
+          </ProblemSolveFooterButton>
+        ) : (
+          <>
+            <ButtonGroup>
+              <ProblemSolveFooterButton type="">
+                <QuestionCircleOutlined />
+                질문하기
+              </ProblemSolveFooterButton>
+              <ProblemSolveFooterButton type="">
+                <MessageOutlined />
+                다른 사람의 답변
+              </ProblemSolveFooterButton>
+            </ButtonGroup>
+            <ButtonGroup>
+              <ProblemSolveFooterButton type="RED" onClick={handleReset}>
+                <RedoOutlined />
+                답변 초기화
+              </ProblemSolveFooterButton>
+              <ProblemSolveFooterButton type="PURPLE" onClick={handleSubmit}>
+                <FileDoneOutlined />
+                답변 제출
+              </ProblemSolveFooterButton>
+            </ButtonGroup>
+          </>
+        )}
+      </BottomBar>
     </BasicPageLayout>
   );
 };

--- a/src/components/pages/ProblemDetailPage/ProblemHistoryTab.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemHistoryTab.style.tsx
@@ -4,14 +4,13 @@ import styled from 'styled-components';
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 16px;
-  background-color: #f9f9f9;
+  padding: 24px 10px 10px 10px;
   overflow: hidden;
 `;
 
 export const SolutionBox = styled.div`
   background-color: #ffffff;
-  padding: 16px;
+  padding: 12px 0px 12px 0px;
   border-radius: 8px;
   margin-bottom: 16px;
   flex: 0.3;
@@ -34,7 +33,7 @@ export const SubTitleBox = styled.div`
   font-weight: bold;
   margin-bottom: 8px;
   padding: 8px 16px;
-  border-radius: 10px;
+  border-radius: 6px;
   display: inline-block;
   width: fit-content;
 `;


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-211](https://soma-til.atlassian.net/browse/TIL-211)

<br>

## 개요

기술 학습 상세 화면 스타일링

<br>

## 내용
- 기술 학습 화면 : 답변 입력 탭
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/7757484f-5004-4e46-a53d-e2a0b1d1a179">

- 기술 학습 화면 : 히스토리 탭 
<img width="1685" alt="image" src="https://github.com/user-attachments/assets/c06a9fed-cb24-43bf-b537-f4c62e4f9ac3">

<br>

## 리뷰어한테 할 말

- 카테고리 태그는 리스트 화면과 함께 수정할 예정입니다. 
- 히스토리 탭이나 모달 세세한 스타일링은 추후 수정할 예정입니다. 


[TIL-211]: https://soma-til.atlassian.net/browse/TIL-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ