### PR TITLE
[TIL-218] 기술학습 제출 결과 모달 & 내 답변 기록 히스토리 영역 스타일링

### DIFF
--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.style.tsx
@@ -148,12 +148,6 @@ export const ButtonGroup = styled.div`
   gap: 10px;
 `;
 
-export const CustomButton = styled(Button)`
-  width: 150px;
-  height: 50px;
-  font-size: 14px;
-`;
-
 export const ProblemSolveFooterButton = styled.button<{ type: string }>`
   display: flex;
   gap: 8px;  
@@ -207,6 +201,20 @@ export const ProblemSolveFooterButton = styled.button<{ type: string }>`
           return '#eee';
       }
     }}
+`;
+
+export const ModalInnerButton = styled(Button)`
+  width: 120px;
+  height: 50px;
+  font-size: 14px;
+`;
+
+export const ModalInnerText = styled.p<{ color?: string }>`
+  margin: 15px 0;
+  text-align: center;
+  font-size: 18px;
+  font-weight: bold;
+  color: ${({ color }) => color || BLACK};
 `;
 
 export const BookMarkIcon = ({

--- a/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemDetailPage.tsx
@@ -6,7 +6,7 @@ import Loading from '@components/common/loading/Loading';
 import { useToast } from '@components/common/notification/ToastProvider';
 import BasicPageLayout from '@components/layout/BasicPageLayout';
 import { TOAST_TYPE } from '@constants/toast';
-import { GRADING_STATUS } from '@constants/grading';
+import { getGradingResultColor, GRADING_STATUS } from '@constants/grading';
 import {
   SubmitInfo,
   getProblemDetail,
@@ -37,7 +37,8 @@ import {
   ContentContainer,
   QuestionSection,
   AnswerSection,
-  CustomButton,
+  ModalInnerButton,
+  ModalInnerText,
   TextDiv,
   ButtonGroup,
   BookMarkIcon,
@@ -61,7 +62,7 @@ const ProblemDetailPage: React.FC = () => {
   const [problemDetail, setProblemDetail] = useState<ProblemDetailInfo>({} as ProblemDetailInfo);
   const [error, setError] = useState<string | null>();
   const [answer, setAnswer] = useState<string>('');
-  const [result, setResult] = useState<string | null>(null);
+  const [result, setResult] = useState<string | undefined>(undefined);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [activeTab, setActiveTab] = useState(ANSWER);
   const [loadingSubmitResult, setLoadingSubmitResult] = useState(false);
@@ -152,12 +153,12 @@ const ProblemDetailPage: React.FC = () => {
 
   const handleModalClose = () => {
     setIsModalVisible(false);
-    setResult(null);
+    setResult(undefined);
   };
 
   const handleMoveHistoryTab = () => {
     setIsModalVisible(false);
-    setResult(null);
+    setResult(undefined);
     setActiveTab(HISTORY);
   };
 
@@ -247,15 +248,17 @@ const ProblemDetailPage: React.FC = () => {
         </ContentContainer>
         <Modal
           title="채점 결과"
+          centered
+          width={300}
           open={isModalVisible}
           footer={[
-            <CustomButton key="back" onClick={handleMoveHistoryTab}>
+            <ModalInnerButton key="back" onClick={handleMoveHistoryTab}>
               피드백 보러가기
-            </CustomButton>,
+            </ModalInnerButton>,
           ]}
           onCancel={handleModalClose}
         >
-          <p>{result}</p>
+          <ModalInnerText color={getGradingResultColor(result)}>{result}</ModalInnerText>
         </Modal>
       </ProblemDetailContainer>
       <BottomBar>

--- a/src/components/pages/ProblemDetailPage/ProblemHistoryTab.tsx
+++ b/src/components/pages/ProblemDetailPage/ProblemHistoryTab.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
+import { AlignType } from 'rc-table/lib/interface';
 import { useToast } from '@components/common/notification/ToastProvider';
 import { getProblemSubmitHistory } from '@services/api/problemService';
 import { TOAST_TYPE } from '@constants/toast';
+import { getGradingResultColor } from '@constants/grading';
 import { ProblemHistoryInfo, ProblemSubmitHistoryInfo } from '@type/problem';
 import formatDate from '@utils/time';
 import { getErrorMessage } from '@utils/errorHandler';
@@ -11,18 +13,34 @@ import { Container, SolutionBox, StyledTable, SubTitleBox } from './ProblemHisto
 
 const CAN_NOT_VIEW_SOLUTION = '문제를 PASS해야 솔루션을 볼 수 있습니다.';
 
-const createColumnSetting = (title: string, dataIndex: string, width: number) => ({
+const createColumnSetting = (
+  title: string,
+  dataIndex: string,
+  width: number,
+  render?: (text: string) => React.ReactNode,
+  align: AlignType = 'left',
+) => ({
   title,
   dataIndex,
   key: dataIndex,
   width,
+  align,
+  render: render || ((text: string) => text),
 });
 
 const columns: TableColumnsType<ProblemHistoryInfo> = [
+  createColumnSetting(
+    '결과',
+    'result',
+    80,
+    (text) => (
+      <span style={{ color: getGradingResultColor(text), fontWeight: 'bold' }}>{text}</span>
+    ),
+    'center',
+  ),
   createColumnSetting('답변', 'answer', 300),
   createColumnSetting('피드백', 'comment', 300),
   createColumnSetting('제출 날짜', 'submittedDate', 150),
-  createColumnSetting('결과', 'result', 100),
 ];
 
 const ProblemHistory: React.FC<{ problemId: string }> = ({ problemId }) => {

--- a/src/constants/grading.ts
+++ b/src/constants/grading.ts
@@ -1,3 +1,5 @@
+import { BLACK, GREEN, RED2 } from '@styles/pallete';
+
 export const GRADING_STATUS = {
   PENDING: 'PENDING',
   COMPLETED: 'COMPLETED',
@@ -7,4 +9,15 @@ export const GRADING_STATUS = {
 export const GRADING_RESULT = {
   PASS: 'PASS',
   FAIL: 'FAIL',
+};
+
+export const getGradingResultColor = (result: string | undefined) => {
+  switch (result) {
+    case GRADING_RESULT.PASS:
+      return GREEN;
+    case GRADING_RESULT.FAIL:
+      return RED2;
+    default:
+      return BLACK;
+  }
 };

--- a/src/styles/pallete.ts
+++ b/src/styles/pallete.ts
@@ -20,3 +20,5 @@ export const BLUE = '#0589f5';
 
 export const LIGHT_RED = '#F16060';
 export const RED = '#c73232';
+export const RED2 = '#FF0000';
+export const GREEN = '#28c528';


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-218](https://soma-til.atlassian.net/browse/TIL-218)

<br>

## 개요
기술학습 제출 결과 모달 & 내 답변 기록 히스토리 영역 스타일링


<br>

## 내용
#### 제출 결과 모달 스타일링
- PASS  
   <img width="500" alt="image" src="https://github.com/user-attachments/assets/772f044b-046b-43f2-bab8-1dc821de3ea6">

- FAIL  
   <img width="500" alt="image" src="https://github.com/user-attachments/assets/7c931fe3-03b9-467d-894e-61b63b837a9b">

<br>

#### 내 답변 기록 히스토리 영역 스타일링
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b5023072-b317-4adc-a4b0-5b60fec6fa70">


<br><br>

## 리뷰어한테 할 말
🌱

[TIL-218]: https://soma-til.atlassian.net/browse/TIL-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ