### PR TITLE
[TIL-224] 초기 사이트 로딩시 토큰 정보 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { ToastProvider } from '@components/common/notification/ToastProvider';
@@ -10,33 +10,47 @@ import ProblemListPage from '@components/pages/ProblemListPage/ProblemListPage';
 import ProblemDetailPage from '@components/pages/ProblemDetailPage/ProblemDetailPage';
 import MyPageChangePassword from '@components/pages/MyPage/MyPageChangePassword';
 import MyPageChangeInfo from '@components/pages/MyPage/MyPageChangeInfo';
-
-import GlobalStyle from '@styles/GlobalStyle';
 import InterviewPage from '@components/pages/InterviewPage/InterviewPage';
+import GlobalStyle from '@styles/GlobalStyle';
+import { getCookie } from '@services/cookie';
+import { REFRESH_TOKEN } from '@constants/auth';
+import { initialSettingTokens } from '@services/api/authService';
+
 import PrivateRoute from './route';
 
-const App: React.FC = () => (
-  <ToastProvider>
-    <GlobalStyle />
-    <Routes>
-      {/* 인증 여부 상관 없이 접속 가능한 페이지 정의 */}
-      <Route path="/" element={<MainPage />} />
-      <Route path="/problem" element={<ProblemListPage />} />
-      <Route path="/problem/:id" element={<ProblemDetailPage />} />
-      {/* 인증이 필요한 페이지 정의 */}
-      <Route element={<PrivateRoute />}>
-        <Route path="/mypage" element={<MyPageChangeInfo />} />
-        <Route path="/mypage/change-password" element={<MyPageChangePassword />} />
-        <Route path="/interview" element={<InterviewIntroPage />} />
-        <Route path="/interview/:code" element={<InterviewPage />} />
-      </Route>
-      {/* 인증을 하지 않아야만 접속 가능한 페이지 정의 */}
-      <Route element={<PrivateRoute authentication={false} />}>
-        <Route path="/join" element={<JoinPage />} />
-        <Route path="/login" element={<LoginPage />} />
-      </Route>
-    </Routes>
-  </ToastProvider>
-);
+const App: React.FC = () => {
+  useEffect(() => {
+    const initializeTokens = async () => {
+      if (getCookie(REFRESH_TOKEN)) {
+        await initialSettingTokens();
+      }
+    };
+    initializeTokens();
+  }, []);
+
+  return (
+    <ToastProvider>
+      <GlobalStyle />
+      <Routes>
+        {/* 인증 여부 상관 없이 접속 가능한 페이지 정의 */}
+        <Route path="/" element={<MainPage />} />
+        <Route path="/problem" element={<ProblemListPage />} />
+        <Route path="/problem/:id" element={<ProblemDetailPage />} />
+        {/* 인증이 필요한 페이지 정의 */}
+        <Route element={<PrivateRoute />}>
+          <Route path="/mypage" element={<MyPageChangeInfo />} />
+          <Route path="/mypage/change-password" element={<MyPageChangePassword />} />
+          <Route path="/interview" element={<InterviewIntroPage />} />
+          <Route path="/interview/:code" element={<InterviewPage />} />
+        </Route>
+        {/* 인증을 하지 않아야만 접속 가능한 페이지 정의 */}
+        <Route element={<PrivateRoute authentication={false} />}>
+          <Route path="/join" element={<JoinPage />} />
+          <Route path="/login" element={<LoginPage />} />
+        </Route>
+      </Routes>
+    </ToastProvider>
+  );
+};
 
 export default App;

--- a/src/components/pages/LoginPage/LoginPage.tsx
+++ b/src/components/pages/LoginPage/LoginPage.tsx
@@ -32,7 +32,7 @@ const LoginPage: React.FC = () => {
       const response = await login(loginData);
       const { token, user } = response.result as { token: Token; user: UserInfo };
 
-      useAuthStore.getState().login(token);
+      useAuthStore.getState().setTokens(token);
       useUserInfoStore.getState().setNickname(user.nickname);
 
       navigate('/');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
@@ -10,9 +9,7 @@ if (!rootElement) {
 
 const root = ReactDOM.createRoot(rootElement);
 root.render(
-  <React.StrictMode>
-    <Router>
-      <App />
-    </Router>
-  </React.StrictMode>,
+  <Router>
+    <App />
+  </Router>,
 );

--- a/src/services/api/authService.ts
+++ b/src/services/api/authService.ts
@@ -1,0 +1,41 @@
+/* eslint-disable */
+import { formatBearerToken, REFRESH_TOKEN } from '@constants/auth';
+import apiClient from '@services/api/axios';
+import { getCookie } from '@services/cookie';
+import useAuthStore from '@store/useAuthStore';
+import { ApiResponse } from '@type/api';
+import { Token } from '@type/auth';
+
+export const reissueToken = async (): Promise<ApiResponse> => {
+  const refreshToken = getCookie(REFRESH_TOKEN);
+  if (!refreshToken) {
+    console.error('Refresh token is missing or invalid.');
+    throw new Error('Refresh token is missing.');
+  }
+
+  const response = await apiClient.get('/auth/reissue', {
+    skipInterceptor: true,
+    headers: {
+      Authorization: formatBearerToken(refreshToken),
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response || !response.data) {
+    console.error('Failed to reissue token:', response);
+    throw new Error('Failed to reissue token.');
+  }
+
+  return response.data;
+};
+
+export const initialSettingTokens = async (): Promise<void> => {
+  try {
+    const response = await reissueToken();
+    const { token } = response.result as { token: Token };
+    useAuthStore.getState().setTokens(token);
+  } catch (error) {
+    console.error('Failed to set initial tokens:', error);
+    useAuthStore.getState().clearTokens();
+  }
+};

--- a/src/services/api/axios.ts
+++ b/src/services/api/axios.ts
@@ -49,6 +49,11 @@ apiClient.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config; // 실패한 요청 정보를 가져옴
 
+    // 인터셉터를 건너뛰기 위한 조건
+    if (originalRequest.skipInterceptor) {
+      return Promise.reject(error); // 요청이 인터셉터를 건너뛰도록 설정된 경우 에러 반환
+    }
+
     // 401 Unauthorized 에러가 발생하고, 아직 재시도를 하지 않은 경우
     if (error.response.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true; // 재시도 플래그 설정

--- a/src/store/clear.ts
+++ b/src/store/clear.ts
@@ -2,7 +2,7 @@ import useAuthStore from '@store/useAuthStore';
 import useUserInfoStore from '@store/useUserInfoStore';
 
 export const logoutClearStores = () => {
-  useAuthStore.getState().reset();
+  useAuthStore.getState().clearTokens();
   useUserInfoStore.getState().reset();
 };
 

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -3,18 +3,18 @@ import { getCookie, removeCookie, setCookie } from '@services/cookie';
 import storeSupport from '@store/support';
 import { Token } from '@type/auth';
 
-interface AccessTokenInfo {
+interface TokenInfo {
   isAuthenticated: boolean;
   checkAuthentication: () => void;
   accessToken: string;
   setAccessToken: (accessToken: string) => void;
   getAccessToken: () => string;
   deleteAccessToken: () => void;
-  login: (token: Token) => void;
-  reset: () => void;
+  setTokens: (token: Token) => void;
+  clearTokens: () => void;
 }
 
-const useAuthStore = storeSupport<AccessTokenInfo>(
+const useAuthStore = storeSupport<TokenInfo>(
   (set, get) => ({
     accessToken: '',
     setAccessToken: (accessToken) => set({ accessToken }),
@@ -24,12 +24,12 @@ const useAuthStore = storeSupport<AccessTokenInfo>(
     checkAuthentication: () => {
       set({ isAuthenticated: Boolean(getCookie(REFRESH_TOKEN)) });
     },
-    login: (token) => {
+    setTokens: (token) => {
       setCookie(REFRESH_TOKEN, token.refreshToken);
       get().setAccessToken(token.accessToken);
       set({ isAuthenticated: true });
     },
-    reset: () => {
+    clearTokens: () => {
       removeCookie(REFRESH_TOKEN);
       get().deleteAccessToken();
       set({ isAuthenticated: false });

--- a/src/type/api.d.ts
+++ b/src/type/api.d.ts
@@ -1,3 +1,5 @@
+import 'axios';
+
 export interface Status {
   code: string;
   message: string;
@@ -6,4 +8,10 @@ export interface Status {
 export interface ApiResponse<T = unknown> {
   status: Status;
   result?: T;
+}
+
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    skipInterceptor?: boolean;
+  }
 }


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-224](https://soma-til.atlassian.net/browse/TIL-224)

<br>

## 개요
초기 사이트 로딩시 토큰 정보 설정

<br>

## 내용
- 초기 사이트 로딩시 refresh 토큰이 있으면 토큰 정보 재발행하여 토큰 정보 설정
- authStore 일부 함수명 변경
- useEffect 두번 호출을 막기 위한 React.StrictMode 제거

<br>

## 리뷰어한테 할 말
🐤

[TIL-224]: https://soma-til.atlassian.net/browse/TIL-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ