### PR TITLE
[TIL-229] 모의면접 진행 기능 프론트엔드 연결

### DIFF
--- a/src/components/pages/InterviewPage/InterviewHeader.tsx
+++ b/src/components/pages/InterviewPage/InterviewHeader.tsx
@@ -4,12 +4,16 @@ import {
   InterviewHeaderLogo,
 } from './InterviewHeader.style';
 
-const InterviewHeader: React.FC = () => (
+interface InterviewHeaderProps {
+  handleInterviewSubmit: React.MouseEventHandler;
+}
+
+const InterviewHeader: React.FC<InterviewHeaderProps> = ({ handleInterviewSubmit }) => (
   <InterviewHeaderContainer>
     <InterviewHeaderLogo>
       <img src="/images/TIL_logo.png" alt="TIL_logo" />
     </InterviewHeaderLogo>
-    <InterviewHeaderButton>면접 종료하기</InterviewHeaderButton>
+    <InterviewHeaderButton onClick={handleInterviewSubmit}>면접 종료하기</InterviewHeaderButton>
   </InterviewHeaderContainer>
 );
 

--- a/src/components/pages/InterviewPage/InterviewMain.tsx
+++ b/src/components/pages/InterviewPage/InterviewMain.tsx
@@ -13,14 +13,16 @@ interface InterviewMainProps {
   solvedProblemList: InterviewProblemInfo[];
   unSolvedProblemList: InterviewProblemInfo[];
   currentSequence: number;
+  currentAnswer: string;
+  handleTextArea: React.ChangeEventHandler;
 }
 
 const InterviewMain: React.FC<InterviewMainProps> = ({
   solvedProblemList,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   unSolvedProblemList,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   currentSequence,
+  currentAnswer,
+  handleTextArea,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -45,10 +47,23 @@ const InterviewMain: React.FC<InterviewMainProps> = ({
               ''
             ),
           )}
+          {unSolvedProblemList.length === 0 ? (
+            <InterviewMessageBox
+              type="interviewer"
+              text="모든 면접 문제를 풀었습니다. 우측 상단의 면접 종료 버튼을 클릭해주세요."
+              time=""
+            />
+          ) : (
+            ''
+          )}
           <div ref={scrollRef} />
         </InterviewMessageContainer>
         <InterviewInputContainer>
-          <InterviewInputTextArea placeholder="답변을 입력하세요." />
+          <InterviewInputTextArea
+            value={currentAnswer}
+            placeholder="답변을 입력하세요."
+            onChange={handleTextArea}
+          />
         </InterviewInputContainer>
       </InterviewContentContainer>
     </InterviewMainContainer>

--- a/src/services/api/InterviewService.ts
+++ b/src/services/api/InterviewService.ts
@@ -16,6 +16,11 @@ export interface InterviewInfoData {
   problemList: InterviewProblemInfo[];
 }
 
+export interface InterviewProblemSolveData {
+  sequence: number;
+  answer: string;
+}
+
 export const createInterview = async (
   data: InterviewCreateData,
 ): Promise<ApiResponse<InterviewCodeData>> => {
@@ -25,5 +30,18 @@ export const createInterview = async (
 
 export const getInterviewInfo = async (code: string): Promise<ApiResponse<InterviewInfoData>> => {
   const response = await apiClient.get(`/interview/${code}`);
+  return response.data;
+};
+
+export const solveInterviewProblem = async (
+  code: string,
+  data: InterviewProblemSolveData,
+): Promise<ApiResponse> => {
+  const response = await apiClient.patch(`/interview/${code}/solve`, data);
+  return response.data;
+};
+
+export const submitInterview = async (code: string): Promise<ApiResponse> => {
+  const response = await apiClient.post(`/interview/${code}/submit`);
   return response.data;
 };


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-229](https://soma-til.atlassian.net/browse/TIL-229)

<br>

## 개요

- 모의면접 진행 기능 프론트엔드 연결

<br>

## 내용

https://github.com/user-attachments/assets/1a0a1b9d-7fbf-4f7f-bf19-f38bea3f16a5

### 모의 면접 답변 제출 기능
- 모의 면접 답변을 제출하기 위한 API 요청 코드 추가
- 실제로 `textarea` 에 작성한 내용이 반영되도록 수정
- `SKIP` 버튼 사용 시, 답변 내용을 `SKIP` 으로 제출
- 답변 제출 버튼 사용 시, 입력한 내용을 제출
- 모든 문제를 풀면 면접관 메시지로 종료를 알림

### 모의 면접 종료 기능
- 모의 면접을 종료하기 위한 API 요청 코드 추가
- 모든 문제를 풀지 않으면 종료할 수 없고, TOAST 알림
- 모든 문제를 풀면 종료 가능

<br>

## 리뷰어한테 할 말

🥵


[TIL-229]: https://soma-til.atlassian.net/browse/TIL-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ